### PR TITLE
Support url tar gz dependencies

### DIFF
--- a/lib/vet/index.js
+++ b/lib/vet/index.js
@@ -12,7 +12,24 @@ module.exports = function(data) {
       if (inDeps === undefined && inDevs === undefined) return reject(new Error('module "'+module+'" not found in package.json'));
       data.moduleVersions[module] = inDeps || inDevs;
     }
-    vetThemAll(data).then(resolve).catch(reject);
+    resolveUrls(data).then(data => vetThemAll(data)).then(resolve).catch(reject);
   });
 };
+
+function resolveUrls(data) {
+  return new Promise(function(resolve, reject) {
+    var modulesWithUrls = Object.keys(data.moduleVersions).filter(module => data.moduleVersions[module].match(/http[s]{0,1}:\/\//));
+    Promise.all(modulesWithUrls.map(m => getVersionFromTarball(m, data.moduleVersions[m]))).then(function(versions) {
+      versions.forEach(function(vv) {
+        data.moduleVersions[vv[0]] = vv[1];     
+      });
+      resolve(data);
+    }).catch(reject);
+  });
+}
+
+function getVersionFromTarball(module, url) {
+  console.log('module', module, url);
+  return Promise.resolve([module, 'fail']);
+}
 

--- a/lib/vet/index.js
+++ b/lib/vet/index.js
@@ -26,10 +26,41 @@ function resolveUrls(data) {
       resolve(data);
     }).catch(reject);
   });
-}
+};
+
+var tar = require('tar');
+var got = require('got');
+var zlib = require('zlib');
 
 function getVersionFromTarball(module, url) {
-  console.log('module', module, url);
-  return Promise.resolve([module, 'fail']);
+        console.log(module, url);
+  return new Promise(function(resolve, reject) {
+    var stream = got.stream(url).pipe(zlib.Unzip()).pipe(tar.Parse());
+    var child = null;
+    stream.on('entry', function(arg) {
+      if (child !== null || arg.path.split('/')[1] !== 'package.json') return;
+      child = new Promise(function(resolve, reject) {
+        var fullStr = '';
+        arg.on('data', function(str) {
+          fullStr += str.toString();
+        });
+        arg.on('end', function() {
+          try {
+            var json = JSON.parse(fullStr);
+            if (json.name !== module) return reject(new Error('Found name:'+json.name+' in package.json from at '+url+'. Expected '+module));
+            resolve([module, json.version]);
+          }
+          catch (err) {
+            reject(err);
+          }
+        });
+      });
+    });
+    stream.on('error', reject);
+    stream.on('end', function() {
+      child = child || Promise.reject(new Error('No package.json found at '+url+' for '+module));
+      child.then(resolve).catch(reject);
+    });
+  });
 }
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "main": "index.js",
   "dependencies": {
     "astw": "2.0.0",
+    "got": "^6.7.1",
     "parents": "1.0.1",
     "resolve": "1.2.0",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "tar": "^2.2.1"
   },
   "devDependencies": {
     "tape": "4.6.3"

--- a/test/fixtures/tarball-fail-package/index.js
+++ b/test/fixtures/tarball-fail-package/index.js
@@ -1,0 +1,1 @@
+require('npm');

--- a/test/fixtures/tarball-fail-package/node_modules/npm/package.json
+++ b/test/fixtures/tarball-fail-package/node_modules/npm/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "jsonify",
+  "version": "0.0.0",
+  "description": "JSON without touching any globals",
+  "main": "index.js",
+  "directories": {
+    "lib": ".",
+    "test": "test"
+  },
+  "devDependencies": {
+    "tap": "0.4.x",
+    "garbage": "0.0.x"
+  },
+  "scripts": {
+    "test": "tap test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/substack/jsonify.git"
+  },
+  "keywords": [
+    "json",
+    "browser"
+  ],
+  "author": {
+    "name": "Douglas Crockford",
+    "url": "http://crockford.com/"
+  },
+  "license": "Public Domain",
+  "readme": "# jsonify\n\nThis module provides Douglas Crockford's JSON implementation without modifying\nany globals.\n\n`stringify` and `parse` are merely exported without respect to whether or not a\nglobal `JSON` object exists.\n\n[![build status](https://secure.travis-ci.org/substack/jsonify.png)](http://travis-ci.org/substack/jsonify)\n\n# methods\n\n``` js\nvar json = require('jsonify');\n```\n\n## json.parse(source, reviver)\n\nReturn a new javascript object from a parse of the `source` string.\n\nIf a `reviver` function is specified, walk the structure passing each name/value\npair to `reviver.call(parent, key, value)` to transform the `value` before\nparsing it.\n\n## json.stringify(value, replacer, space)\n\nReturn a string representation for `value`.\n\nIf `replacer` is specified, walk the structure passing each name/value pair to\n`replacer.call(parent, key, value)` to transform the `value` before stringifying\nit.\n\nIf `space` is a number, indent the result by that many spaces.\nIf `space` is a string, use `space` as the indentation.\n\n# install\n\nWith [npm](http://npmjs.org) do:\n\n```\nnpm install jsonify\n```\n\nTo use this module in the browser, check out\n[browserify](https://github.com/substack/node-browserify).\n\n# license\n\npublic domain\n",
+  "readmeFilename": "readme.markdown",
+  "bugs": {
+    "url": "https://github.com/substack/jsonify/issues"
+  },
+  "homepage": "https://github.com/substack/jsonify#readme",
+  "_id": "jsonify@0.0.0",
+  "_shasum": "ee568a2b1efaeb95bec4d9e59e5301fc63339866",
+  "_resolved": "https://github.com/substack/jsonify/tarball/master",
+  "_from": "https://github.com/substack/jsonify/tarball/master"
+}

--- a/test/fixtures/tarball-fail-package/package.json
+++ b/test/fixtures/tarball-fail-package/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tarball-fail",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "npm": "https://github.com/substack/jsonify/tarball/master"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/test/fixtures/tarball-fail-version/index.js
+++ b/test/fixtures/tarball-fail-version/index.js
@@ -1,0 +1,1 @@
+require('npm');

--- a/test/fixtures/tarball-fail-version/node_modules/npm/package.json
+++ b/test/fixtures/tarball-fail-version/node_modules/npm/package.json
@@ -1,0 +1,1984 @@
+{
+  "version": "3.10.10",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "keywords": [
+    "install",
+    "modules",
+    "package manager",
+    "package.json"
+  ],
+  "preferGlobal": true,
+  "config": {
+    "publishtest": false
+  },
+  "homepage": "https://docs.npmjs.com/",
+  "author": {
+    "name": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/npm.git"
+  },
+  "bugs": {
+    "url": "https://github.com/npm/npm/issues"
+  },
+  "directories": {
+    "bin": "./bin",
+    "doc": "./doc",
+    "lib": "./lib",
+    "man": "./man"
+  },
+  "main": "./lib/npm.js",
+  "bin": {
+    "npm": "./bin/npm-cli.js"
+  },
+  "dependencies": {
+    "abbrev": "~1.0.9",
+    "ansicolors": "~0.3.2",
+    "ansistyles": "~0.1.3",
+    "aproba": "~1.0.4",
+    "archy": "~1.0.0",
+    "asap": "~2.0.5",
+    "chownr": "~1.0.1",
+    "cmd-shim": "~2.0.2",
+    "columnify": "~1.5.4",
+    "config-chain": "~1.1.11",
+    "dezalgo": "~1.0.3",
+    "editor": "~1.0.0",
+    "fs-vacuum": "~1.2.9",
+    "fs-write-stream-atomic": "~1.0.8",
+    "fstream": "~1.0.10",
+    "fstream-npm": "~1.2.0",
+    "glob": "~7.1.0",
+    "graceful-fs": "~4.1.9",
+    "has-unicode": "~2.0.1",
+    "hosted-git-info": "~2.1.5",
+    "iferr": "~0.1.5",
+    "inflight": "~1.0.5",
+    "inherits": "~2.0.3",
+    "ini": "~1.3.4",
+    "init-package-json": "~1.9.4",
+    "lockfile": "~1.0.2",
+    "lodash._baseuniq": "~4.6.0",
+    "lodash.clonedeep": "~4.5.0",
+    "lodash.union": "~4.6.0",
+    "lodash.uniq": "~4.5.0",
+    "lodash.without": "~4.4.0",
+    "mkdirp": "~0.5.1",
+    "node-gyp": "~3.4.0",
+    "nopt": "~3.0.6",
+    "normalize-git-url": "~3.0.2",
+    "normalize-package-data": "~2.3.5",
+    "npm-cache-filename": "~1.0.2",
+    "npm-install-checks": "~3.0.0",
+    "npm-package-arg": "~4.2.0",
+    "npm-registry-client": "~7.2.1",
+    "npm-user-validate": "~0.1.5",
+    "npmlog": "~4.0.0",
+    "once": "~1.4.0",
+    "opener": "~1.4.2",
+    "osenv": "~0.1.3",
+    "path-is-inside": "~1.0.2",
+    "read": "~1.0.7",
+    "read-cmd-shim": "~1.0.1",
+    "read-installed": "~4.0.3",
+    "read-package-json": "~2.0.4",
+    "read-package-tree": "~5.1.5",
+    "readable-stream": "~2.1.5",
+    "realize-package-specifier": "~3.0.3",
+    "request": "~2.75.0",
+    "retry": "~0.10.0",
+    "rimraf": "~2.5.4",
+    "semver": "~5.3.0",
+    "sha": "~2.0.1",
+    "slide": "~1.1.6",
+    "sorted-object": "~2.0.1",
+    "strip-ansi": "~3.0.1",
+    "tar": "~2.2.1",
+    "text-table": "~0.2.0",
+    "uid-number": "0.0.6",
+    "umask": "~1.1.0",
+    "unique-filename": "~1.1.0",
+    "unpipe": "~1.0.0",
+    "validate-npm-package-name": "~2.2.2",
+    "which": "~1.2.11",
+    "wrappy": "~1.0.2",
+    "write-file-atomic": "~1.2.0",
+    "ansi-regex": "*",
+    "debuglog": "*",
+    "imurmurhash": "*",
+    "lodash._baseindexof": "*",
+    "lodash._bindcallback": "*",
+    "lodash._cacheindexof": "*",
+    "lodash._createcache": "*",
+    "lodash._getnative": "*",
+    "lodash.restparam": "*",
+    "readdir-scoped-modules": "*",
+    "validate-npm-package-license": "*"
+  },
+  "bundleDependencies": [
+    "abbrev",
+    "ansi-regex",
+    "ansicolors",
+    "ansistyles",
+    "aproba",
+    "archy",
+    "asap",
+    "chownr",
+    "cmd-shim",
+    "columnify",
+    "config-chain",
+    "debuglog",
+    "dezalgo",
+    "editor",
+    "fs-vacuum",
+    "fs-write-stream-atomic",
+    "fstream",
+    "fstream-npm",
+    "glob",
+    "graceful-fs",
+    "has-unicode",
+    "hosted-git-info",
+    "iferr",
+    "imurmurhash",
+    "inflight",
+    "inherits",
+    "ini",
+    "init-package-json",
+    "lockfile",
+    "lodash._baseindexof",
+    "lodash._baseuniq",
+    "lodash._bindcallback",
+    "lodash._cacheindexof",
+    "lodash._createcache",
+    "lodash._getnative",
+    "lodash.clonedeep",
+    "lodash.restparam",
+    "lodash.union",
+    "lodash.uniq",
+    "lodash.without",
+    "mkdirp",
+    "node-gyp",
+    "nopt",
+    "normalize-git-url",
+    "normalize-package-data",
+    "npm-cache-filename",
+    "npm-install-checks",
+    "npm-package-arg",
+    "npm-registry-client",
+    "npm-user-validate",
+    "npmlog",
+    "once",
+    "opener",
+    "osenv",
+    "path-is-inside",
+    "read",
+    "read-cmd-shim",
+    "read-installed",
+    "read-package-json",
+    "read-package-tree",
+    "readable-stream",
+    "readdir-scoped-modules",
+    "realize-package-specifier",
+    "request",
+    "retry",
+    "rimraf",
+    "semver",
+    "sha",
+    "slide",
+    "sorted-object",
+    "strip-ansi",
+    "tar",
+    "text-table",
+    "uid-number",
+    "umask",
+    "unique-filename",
+    "unpipe",
+    "validate-npm-package-license",
+    "validate-npm-package-name",
+    "which",
+    "wrappy",
+    "write-file-atomic"
+  ],
+  "devDependencies": {
+    "deep-equal": "~1.0.1",
+    "marked": "~0.3.6",
+    "marked-man": "~0.1.5",
+    "npm-registry-couchapp": "~2.6.12",
+    "npm-registry-mock": "~1.0.1",
+    "require-inject": "~1.4.0",
+    "sprintf-js": "~1.0.3",
+    "standard": "~6.0.8",
+    "tacks": "~1.2.2",
+    "tap": "~7.1.2"
+  },
+  "scripts": {
+    "dumpconf": "env | grep npm | sort | uniq",
+    "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rimraf test/*/*/node_modules && make doc-clean && make -j4 doc",
+    "preversion": "bash scripts/update-authors.sh && git add AUTHORS && git commit -m \"update AUTHORS\" || true",
+    "tap": "tap --timeout 300",
+    "tap-cover": "tap --coverage --timeout 600",
+    "test": "standard && npm run test-tap",
+    "test-coverage": "npm run tap-cover -- \"test/tap/*.js\" \"test/network/*.js\" \"test/slow/*.js\" \"test/broken-under-*/*.js\"",
+    "test-tap": "npm run tap -- \"test/tap/*.js\" \"test/network/*.js\" \"test/slow/*.js\" \"test/broken-under-*/*.js\"",
+    "test-node": "\"$NODE\" \"node_modules/.bin/tap\" --timeout 240 \"test/tap/*.js\" \"test/network/*.js\" \"test/slow/*.js\" \"test/broken-under-nyc*/*.js\""
+  },
+  "license": "Artistic-2.0",
+  "man": [],
+  "contributors": [
+    {
+      "name": "Isaac Z. Schlueter",
+      "email": "i@izs.me"
+    },
+    {
+      "name": "Steve Steiner",
+      "email": "ssteinerX@gmail.com"
+    },
+    {
+      "name": "Mikeal Rogers",
+      "email": "mikeal.rogers@gmail.com"
+    },
+    {
+      "name": "Aaron Blohowiak",
+      "email": "aaron.blohowiak@gmail.com"
+    },
+    {
+      "name": "Martyn Smith",
+      "email": "martyn@dollyfish.net.nz"
+    },
+    {
+      "name": "Charlie Robbins",
+      "email": "charlie.robbins@gmail.com"
+    },
+    {
+      "name": "Francisco Treacy",
+      "email": "francisco.treacy@gmail.com"
+    },
+    {
+      "name": "Cliffano Subagio",
+      "email": "cliffano@gmail.com"
+    },
+    {
+      "name": "Christian Eager",
+      "email": "christian.eager@nokia.com"
+    },
+    {
+      "name": "Dav Glass",
+      "email": "davglass@gmail.com"
+    },
+    {
+      "name": "Alex K. Wolfe",
+      "email": "alexkwolfe@gmail.com"
+    },
+    {
+      "name": "James Sanders",
+      "email": "jimmyjazz14@gmail.com"
+    },
+    {
+      "name": "Reid Burke",
+      "email": "me@reidburke.com"
+    },
+    {
+      "name": "Arlo Breault",
+      "email": "arlolra@gmail.com"
+    },
+    {
+      "name": "Timo Derstappen",
+      "email": "teemow@gmail.com"
+    },
+    {
+      "name": "Bart Teeuwisse",
+      "email": "bart.teeuwisse@thecodemill.biz"
+    },
+    {
+      "name": "Ben Noordhuis",
+      "email": "info@bnoordhuis.nl"
+    },
+    {
+      "name": "Tor Valamo",
+      "email": "tor.valamo@gmail.com"
+    },
+    {
+      "name": "Whyme.Lyu",
+      "email": "5longluna@gmail.com"
+    },
+    {
+      "name": "Olivier Melcher",
+      "email": "olivier.melcher@gmail.com"
+    },
+    {
+      "name": "Tomaž Muraus",
+      "email": "kami@k5-storitve.net"
+    },
+    {
+      "name": "Evan Meagher",
+      "email": "evan.meagher@gmail.com"
+    },
+    {
+      "name": "Orlando Vazquez",
+      "email": "ovazquez@gmail.com"
+    },
+    {
+      "name": "Kai Chen",
+      "email": "kaichenxyz@gmail.com"
+    },
+    {
+      "name": "George Miroshnykov",
+      "email": "gmiroshnykov@lohika.com"
+    },
+    {
+      "name": "Geoff Flarity",
+      "email": "geoff.flarity@gmail.com"
+    },
+    {
+      "name": "Max Goodman",
+      "email": "c@chromakode.com"
+    },
+    {
+      "name": "Pete Kruckenberg",
+      "email": "pete@kruckenberg.com"
+    },
+    {
+      "name": "Laurie Harper",
+      "email": "laurie@holoweb.net"
+    },
+    {
+      "name": "Chris Wong",
+      "email": "chris@chriswongstudio.com"
+    },
+    {
+      "name": "Scott Bronson",
+      "email": "brons_github@rinspin.com"
+    },
+    {
+      "name": "Federico Romero",
+      "email": "federomero@gmail.com"
+    },
+    {
+      "name": "Visnu Pitiyanuvath",
+      "email": "visnupx@gmail.com"
+    },
+    {
+      "name": "Irakli Gozalishvili",
+      "email": "rfobic@gmail.com"
+    },
+    {
+      "name": "Mark Cahill",
+      "email": "mark@tiemonster.info"
+    },
+    {
+      "name": "Tony",
+      "email": "zearin@gonk.net"
+    },
+    {
+      "name": "Iain Sproat",
+      "email": "iainsproat@gmail.com"
+    },
+    {
+      "name": "Trent Mick",
+      "email": "trentm@gmail.com"
+    },
+    {
+      "name": "Felix Geisendörfer",
+      "email": "felix@debuggable.com"
+    },
+    {
+      "name": "Jameson Little",
+      "email": "t.jameson.little@gmail.com"
+    },
+    {
+      "name": "Conny Brunnkvist",
+      "email": "conny@fuchsia.se"
+    },
+    {
+      "name": "Will Elwood",
+      "email": "w.elwood08@gmail.com"
+    },
+    {
+      "name": "Dean Landolt",
+      "email": "dean@deanlandolt.com"
+    },
+    {
+      "name": "Oleg Efimov",
+      "email": "efimovov@gmail.com"
+    },
+    {
+      "name": "Martin Cooper",
+      "email": "mfncooper@gmail.com"
+    },
+    {
+      "name": "Jann Horn",
+      "email": "jannhorn@googlemail.com"
+    },
+    {
+      "name": "Andrew Bradley",
+      "email": "cspotcode@gmail.com"
+    },
+    {
+      "name": "Maciej Małecki",
+      "email": "me@mmalecki.com"
+    },
+    {
+      "name": "Stephen Sugden",
+      "email": "glurgle@gmail.com"
+    },
+    {
+      "name": "Michael Budde",
+      "email": "mbudde@gmail.com"
+    },
+    {
+      "name": "Jason Smith",
+      "email": "jhs@iriscouch.com"
+    },
+    {
+      "name": "Gautham Pai",
+      "email": "buzypi@gmail.com"
+    },
+    {
+      "name": "David Trejo",
+      "email": "david.daniel.trejo@gmail.com"
+    },
+    {
+      "name": "Paul Vorbach",
+      "email": "paul@vorb.de"
+    },
+    {
+      "name": "George Ornbo",
+      "email": "george@shapeshed.com"
+    },
+    {
+      "name": "Tim Oxley",
+      "email": "secoif@gmail.com"
+    },
+    {
+      "name": "Tyler Green",
+      "email": "tyler.green2@gmail.com"
+    },
+    {
+      "name": "Dave Pacheco",
+      "email": "dap@joyent.com"
+    },
+    {
+      "name": "Danila Gerasimov",
+      "email": "danila.gerasimov@gmail.com"
+    },
+    {
+      "name": "Rod Vagg",
+      "email": "rod@vagg.org"
+    },
+    {
+      "name": "Christian Howe",
+      "email": "coderarity@gmail.com"
+    },
+    {
+      "name": "Andrew Lunny",
+      "email": "alunny@gmail.com"
+    },
+    {
+      "name": "Henrik Hodne",
+      "email": "dvyjones@binaryhex.com"
+    },
+    {
+      "name": "Adam Blackburn",
+      "email": "regality@gmail.com"
+    },
+    {
+      "name": "Kris Windham",
+      "email": "kriswindham@gmail.com"
+    },
+    {
+      "name": "Jens Grunert",
+      "email": "jens.grunert@gmail.com"
+    },
+    {
+      "name": "Joost-Wim Boekesteijn",
+      "email": "joost-wim@boekesteijn.nl"
+    },
+    {
+      "name": "Dalmais Maxence",
+      "email": "root@ip-10-195-202-5.ec2.internal"
+    },
+    {
+      "name": "Marcus Ekwall",
+      "email": "marcus.ekwall@gmail.com"
+    },
+    {
+      "name": "Aaron Stacy",
+      "email": "aaron.r.stacy@gmail.com"
+    },
+    {
+      "name": "Phillip Howell",
+      "email": "phowell@cothm.org"
+    },
+    {
+      "name": "Domenic Denicola",
+      "email": "domenic@domenicdenicola.com"
+    },
+    {
+      "name": "James Halliday",
+      "email": "mail@substack.net"
+    },
+    {
+      "name": "Jeremy Cantrell",
+      "email": "jmcantrell@gmail.com"
+    },
+    {
+      "name": "Ribettes",
+      "email": "patlogan29@gmail.com"
+    },
+    {
+      "name": "Don Park",
+      "email": "donpark@docuverse.com"
+    },
+    {
+      "name": "Einar Otto Stangvik",
+      "email": "einaros@gmail.com"
+    },
+    {
+      "name": "Kei Son",
+      "email": "heyacct@gmail.com"
+    },
+    {
+      "name": "Nicolas Morel",
+      "email": "marsup@gmail.com"
+    },
+    {
+      "name": "Mark Dube",
+      "email": "markisdee@gmail.com"
+    },
+    {
+      "name": "Nathan Rajlich",
+      "email": "nathan@tootallnate.net"
+    },
+    {
+      "name": "Maxim Bogushevich",
+      "email": "boga1@mail.ru"
+    },
+    {
+      "name": "Meaglin",
+      "email": "Meaglin.wasabi@gmail.com"
+    },
+    {
+      "name": "Ben Evans",
+      "email": "ben@bensbit.co.uk"
+    },
+    {
+      "name": "Nathan Zadoks",
+      "email": "nathan@nathan7.eu"
+    },
+    {
+      "name": "Brian White",
+      "email": "mscdex@mscdex.net"
+    },
+    {
+      "name": "Jed Schmidt",
+      "email": "tr@nslator.jp"
+    },
+    {
+      "name": "Ian Livingstone",
+      "email": "ianl@cs.dal.ca"
+    },
+    {
+      "name": "Patrick Pfeiffer",
+      "email": "patrick@buzzle.at"
+    },
+    {
+      "name": "Paul Miller",
+      "email": "paul@paulmillr.com"
+    },
+    {
+      "name": "Ryan Emery",
+      "email": "seebees@gmail.com"
+    },
+    {
+      "name": "Carl Lange",
+      "email": "carl@flax.ie"
+    },
+    {
+      "name": "Jan Lehnardt",
+      "email": "jan@apache.org"
+    },
+    {
+      "name": "Stuart P. Bentley",
+      "email": "stuart@testtrack4.com"
+    },
+    {
+      "name": "Johan Sköld",
+      "email": "johan@skold.cc"
+    },
+    {
+      "name": "Stuart Knightley",
+      "email": "stuart@stuartk.com"
+    },
+    {
+      "name": "Niggler",
+      "email": "nirk.niggler@gmail.com"
+    },
+    {
+      "name": "Paolo Fragomeni",
+      "email": "paolo@async.ly"
+    },
+    {
+      "name": "Jaakko Manninen",
+      "email": "jaakko@rocketpack.fi"
+    },
+    {
+      "name": "Luke Arduini",
+      "email": "luke.arduini@gmail.com"
+    },
+    {
+      "name": "Larz Conwell",
+      "email": "larz@larz-laptop.(none)",
+      "url": "none"
+    },
+    {
+      "name": "Marcel Klehr",
+      "email": "mklehr@gmx.net"
+    },
+    {
+      "name": "Robert Kowalski",
+      "email": "rok@kowalski.gd"
+    },
+    {
+      "name": "Forbes Lindesay",
+      "email": "forbes@lindesay.co.uk"
+    },
+    {
+      "name": "Vaz Allen",
+      "email": "vaz@tryptid.com"
+    },
+    {
+      "name": "Jake Verbaten",
+      "email": "raynos2@gmail.com"
+    },
+    {
+      "name": "Schabse Laks",
+      "email": "Dev@SLaks.net"
+    },
+    {
+      "name": "Florian Margaine",
+      "email": "florian@margaine.com"
+    },
+    {
+      "name": "Johan Nordberg",
+      "email": "its@johan-nordberg.com"
+    },
+    {
+      "name": "Ian Babrou",
+      "email": "ibobrik@gmail.com"
+    },
+    {
+      "name": "Di Wu",
+      "email": "dwu@palantir.com"
+    },
+    {
+      "name": "Mathias Bynens",
+      "email": "mathias@qiwi.be"
+    },
+    {
+      "name": "Matt McClure",
+      "email": "matt.mcclure@mapmyfitness.com"
+    },
+    {
+      "name": "Matt Lunn",
+      "email": "matt@mattlunn.me.uk"
+    },
+    {
+      "name": "Alexey Kreschuk",
+      "email": "akrsch@gmail.com"
+    },
+    {
+      "name": "elisee",
+      "email": "elisee@sparklin.org"
+    },
+    {
+      "name": "Robert Gieseke",
+      "email": "robert.gieseke@gmail.com"
+    },
+    {
+      "name": "François Frisch",
+      "email": "francoisfrisch@gmail.com"
+    },
+    {
+      "name": "Trevor Burnham",
+      "email": "tburnham@hubspot.com"
+    },
+    {
+      "name": "Alan Shaw",
+      "email": "alan@freestyle-developments.co.uk"
+    },
+    {
+      "name": "TJ Holowaychuk",
+      "email": "tj@vision-media.ca"
+    },
+    {
+      "name": "Nicholas Kinsey",
+      "email": "pyro@feisty.io"
+    },
+    {
+      "name": "Paulo Cesar",
+      "email": "pauloc062@gmail.com"
+    },
+    {
+      "name": "Elan Shanker",
+      "email": "elan.shanker@gmail.com"
+    },
+    {
+      "name": "Jon Spencer",
+      "email": "jon@jonspencer.ca"
+    },
+    {
+      "name": "Jason Diamond",
+      "email": "jason@diamond.name"
+    },
+    {
+      "name": "Maximilian Antoni",
+      "email": "mail@maxantoni.de"
+    },
+    {
+      "name": "Thom Blake",
+      "email": "tblake@brightroll.com"
+    },
+    {
+      "name": "Jess Martin",
+      "email": "jessmartin@gmail.com"
+    },
+    {
+      "name": "Spain Train",
+      "email": "michael.spainhower@opower.com"
+    },
+    {
+      "name": "Alex Rodionov",
+      "email": "p0deje@gmail.com"
+    },
+    {
+      "name": "Matt Colyer",
+      "email": "matt@colyer.name"
+    },
+    {
+      "name": "Evan You",
+      "email": "yyx990803@gmail.com"
+    },
+    {
+      "name": "bitspill",
+      "email": "bitspill+github@bitspill.net"
+    },
+    {
+      "name": "Gabriel Falkenberg",
+      "email": "gabriel.falkenberg@gmail.com"
+    },
+    {
+      "name": "Alexej Yaroshevich",
+      "email": "alex@qfox.ru"
+    },
+    {
+      "name": "Quim Calpe",
+      "email": "quim@kalpe.com"
+    },
+    {
+      "name": "Steve Mason",
+      "email": "stevem@brandwatch.com"
+    },
+    {
+      "name": "Wil Moore III",
+      "email": "wil.moore@wilmoore.com"
+    },
+    {
+      "name": "Sergey Belov",
+      "email": "peimei@ya.ru"
+    },
+    {
+      "name": "Tom Huang",
+      "email": "hzlhu.dargon@gmail.com"
+    },
+    {
+      "name": "CamilleM",
+      "email": "camille.moulin@alterway.fr"
+    },
+    {
+      "name": "Sébastien Santoro",
+      "email": "dereckson@espace-win.org"
+    },
+    {
+      "name": "Evan Lucas",
+      "email": "evan@btc.com"
+    },
+    {
+      "name": "Quinn Slack",
+      "email": "qslack@qslack.com"
+    },
+    {
+      "name": "Alex Kocharin",
+      "email": "alex@kocharin.ru"
+    },
+    {
+      "name": "Daniel Santiago",
+      "email": "daniel.santiago@highlevelwebs.com"
+    },
+    {
+      "name": "Denis Gladkikh",
+      "email": "outcoldman@gmail.com"
+    },
+    {
+      "name": "Andrew Horton",
+      "email": "andrew.j.horton@gmail.com"
+    },
+    {
+      "name": "Zeke Sikelianos",
+      "email": "zeke@sikelianos.com"
+    },
+    {
+      "name": "Dylan Greene",
+      "email": "dylang@gmail.com"
+    },
+    {
+      "name": "Franck Cuny",
+      "email": "franck.cuny@gmail.com"
+    },
+    {
+      "name": "Yeonghoon Park",
+      "email": "sola92@gmail.com"
+    },
+    {
+      "name": "Rafael de Oleza",
+      "email": "rafa@spotify.com"
+    },
+    {
+      "name": "Mikola Lysenko",
+      "email": "mikolalysenko@gmail.com"
+    },
+    {
+      "name": "Yazhong Liu",
+      "email": "yorkiefixer@gmail.com"
+    },
+    {
+      "name": "Neil Gentleman",
+      "email": "ngentleman@gmail.com"
+    },
+    {
+      "name": "Kris Kowal",
+      "email": "kris.kowal@cixar.com"
+    },
+    {
+      "name": "Alex Gorbatchev",
+      "email": "alex.gorbatchev@gmail.com"
+    },
+    {
+      "name": "Shawn Wildermuth",
+      "email": "shawn@wildermuth.com"
+    },
+    {
+      "name": "Wesley de Souza",
+      "email": "wesleywex@gmail.com"
+    },
+    {
+      "name": "yoyoyogi",
+      "email": "yogesh.k@gmail.com"
+    },
+    {
+      "name": "J. Tangelder",
+      "email": "j.tangelder@gmail.com"
+    },
+    {
+      "name": "Jean Lauliac",
+      "email": "jean@lauliac.com"
+    },
+    {
+      "name": "Andrey Kislyuk",
+      "email": "kislyuk@gmail.com"
+    },
+    {
+      "name": "Thorsten Lorenz",
+      "email": "thlorenz@gmx.de"
+    },
+    {
+      "name": "Julian Gruber",
+      "email": "julian@juliangruber.com"
+    },
+    {
+      "name": "Benjamin Coe",
+      "email": "bencoe@gmail.com"
+    },
+    {
+      "name": "Alex Ford",
+      "email": "Alex.Ford@CodeTunnel.com"
+    },
+    {
+      "name": "Matt Hickford",
+      "email": "matt.hickford@gmail.com"
+    },
+    {
+      "name": "Sean McGivern",
+      "email": "sean.mcgivern@rightscale.com"
+    },
+    {
+      "name": "C J Silverio",
+      "email": "ceejceej@gmail.com"
+    },
+    {
+      "name": "Robin Tweedie",
+      "email": "robin@songkick.com"
+    },
+    {
+      "name": "Miroslav Bajtoš",
+      "email": "miroslav@strongloop.com"
+    },
+    {
+      "name": "David Glasser",
+      "email": "glasser@davidglasser.net"
+    },
+    {
+      "name": "Gianluca Casati",
+      "email": "casati_gianluca@yahoo.it"
+    },
+    {
+      "name": "Forrest L Norvell",
+      "email": "ogd@aoaioxxysz.net"
+    },
+    {
+      "name": "Karsten Tinnefeld",
+      "email": "k.tinnefeld@googlemail.com"
+    },
+    {
+      "name": "Bryan Burgers",
+      "email": "bryan@burgers.io"
+    },
+    {
+      "name": "David Beitey",
+      "email": "david@davidjb.com"
+    },
+    {
+      "name": "Evan You",
+      "email": "yyou@google.com"
+    },
+    {
+      "name": "Zach Pomerantz",
+      "email": "zmp@umich.edu"
+    },
+    {
+      "name": "Chris Williams",
+      "email": "cwilliams88@gmail.com"
+    },
+    {
+      "name": "sudodoki",
+      "email": "smd.deluzion@gmail.com"
+    },
+    {
+      "name": "Mick Thompson",
+      "email": "dthompson@gmail.com"
+    },
+    {
+      "name": "Felix Rabe",
+      "email": "felix@rabe.io"
+    },
+    {
+      "name": "Michael Hayes",
+      "email": "michael@hayes.io"
+    },
+    {
+      "name": "Chris Dickinson",
+      "email": "christopher.s.dickinson@gmail.com"
+    },
+    {
+      "name": "Bradley Meck",
+      "email": "bradley.meck@gmail.com"
+    },
+    {
+      "name": "GeJ",
+      "email": "geraud@gcu.info"
+    },
+    {
+      "name": "Andrew Terris",
+      "email": "atterris@gmail.com"
+    },
+    {
+      "name": "Michael Nisi",
+      "email": "michael.nisi@gmail.com"
+    },
+    {
+      "name": "fengmk2",
+      "email": "fengmk2@gmail.com"
+    },
+    {
+      "name": "Adam Meadows",
+      "email": "adam.meadows@gmail.com"
+    },
+    {
+      "name": "Chulki Lee",
+      "email": "chulki.lee@gmail.com"
+    },
+    {
+      "name": "不四",
+      "email": "busi.hyy@taobao.com"
+    },
+    {
+      "name": "dead_horse",
+      "email": "dead_horse@qq.com"
+    },
+    {
+      "name": "Kenan Yildirim",
+      "email": "kenan@kenany.me"
+    },
+    {
+      "name": "Laurie Voss",
+      "email": "git@seldo.com"
+    },
+    {
+      "name": "Rebecca Turner",
+      "email": "me@re-becca.org"
+    },
+    {
+      "name": "Hunter Loftis",
+      "email": "hunter@hunterloftis.com"
+    },
+    {
+      "name": "Peter Richardson",
+      "email": "github@zoomy.net"
+    },
+    {
+      "name": "Jussi Kalliokoski",
+      "email": "jussi.kalliokoski@gmail.com"
+    },
+    {
+      "name": "Filip Weiss",
+      "email": "me@fiws.net"
+    },
+    {
+      "name": "Timo Weiß",
+      "email": "timoweiss@Timo-MBP.local"
+    },
+    {
+      "name": "Christopher Hiller",
+      "email": "chiller@badwing.com"
+    },
+    {
+      "name": "Jérémy Lal",
+      "email": "kapouer@melix.org"
+    },
+    {
+      "name": "Anders Janmyr",
+      "email": "anders@janmyr.com"
+    },
+    {
+      "name": "Chris Meyers",
+      "email": "chris.meyers.fsu@gmail.com"
+    },
+    {
+      "name": "Ludwig Magnusson",
+      "email": "ludwig@mediatool.com"
+    },
+    {
+      "name": "Wout Mertens",
+      "email": "Wout.Mertens@gmail.com"
+    },
+    {
+      "name": "Nick Santos",
+      "email": "nick@medium.com"
+    },
+    {
+      "name": "Terin Stock",
+      "email": "terinjokes@gmail.com"
+    },
+    {
+      "name": "Faiq Raza",
+      "email": "faiqrazarizvi@gmail.com"
+    },
+    {
+      "name": "Thomas Torp",
+      "email": "thomas@erupt.no"
+    },
+    {
+      "name": "Sam Mikes",
+      "email": "smikes@cubane.com"
+    },
+    {
+      "name": "Mat Tyndall",
+      "email": "mat.tyndall@gmail.com"
+    },
+    {
+      "name": "Tauren Mills",
+      "email": "tauren@sportzing.com"
+    },
+    {
+      "name": "Ron Martinez",
+      "email": "ramartin.net@gmail.com"
+    },
+    {
+      "name": "Kazuhito Hokamura",
+      "email": "k.hokamura@gmail.com"
+    },
+    {
+      "name": "Tristan Davies",
+      "email": "github@tristan.io"
+    },
+    {
+      "name": "David Volm",
+      "email": "david@volminator.com"
+    },
+    {
+      "name": "Lin Clark",
+      "email": "lin.w.clark@gmail.com"
+    },
+    {
+      "name": "Ben Page",
+      "email": "bpage@dewalch.com"
+    },
+    {
+      "name": "Jeff Jo",
+      "email": "jeffjo@squareup.com"
+    },
+    {
+      "name": "martinvd",
+      "email": "martinvdpub@gmail.com"
+    },
+    {
+      "name": "Mark J. Titorenko",
+      "email": "nospam-github.com@titorenko.net"
+    },
+    {
+      "name": "Oddur Sigurdsson",
+      "email": "oddurs@gmail.com"
+    },
+    {
+      "name": "Eric Mill",
+      "email": "eric@konklone.com"
+    },
+    {
+      "name": "Gabriel Barros",
+      "email": "descartavel1@gmail.com"
+    },
+    {
+      "name": "KevinSheedy",
+      "email": "kevinsheedy@gmail.com"
+    },
+    {
+      "name": "Aleksey Smolenchuk",
+      "email": "aleksey@uber.com"
+    },
+    {
+      "name": "Ed Morley",
+      "email": "emorley@mozilla.com"
+    },
+    {
+      "name": "Blaine Bublitz",
+      "email": "blaine@iceddev.com"
+    },
+    {
+      "name": "Andrey Fedorov",
+      "email": "anfedorov@gmail.com"
+    },
+    {
+      "name": "Daijiro Wachi",
+      "email": "daijiro.wachi@gmail.com"
+    },
+    {
+      "name": "Luc Thevenard",
+      "email": "lucthevenard@gmail.com"
+    },
+    {
+      "name": "Aria Stewart",
+      "email": "aredridel@nbtsc.org"
+    },
+    {
+      "name": "Charlie Rudolph",
+      "email": "charles.w.rudolph@gmail.com"
+    },
+    {
+      "name": "Vladimir Rutsky",
+      "email": "rutsky@users.noreply.github.com"
+    },
+    {
+      "name": "Isaac Murchie",
+      "email": "isaac@saucelabs.com"
+    },
+    {
+      "name": "Marcin Wosinek",
+      "email": "marcin.wosinek@gmail.com"
+    },
+    {
+      "name": "David Marr",
+      "email": "davemarr@gmail.com"
+    },
+    {
+      "name": "Bryan English",
+      "email": "bryan@bryanenglish.com"
+    },
+    {
+      "name": "Anthony Zotti",
+      "email": "amZotti@users.noreply.github.com"
+    },
+    {
+      "name": "Karl Horky",
+      "email": "karl.horky@gmail.com"
+    },
+    {
+      "name": "Jordan Harband",
+      "email": "ljharb@gmail.com"
+    },
+    {
+      "name": "Guðlaugur Stefán Egilsson",
+      "email": "gulli@kolibri.is"
+    },
+    {
+      "name": "Helge Skogly Holm",
+      "email": "helge.holm@gmail.com"
+    },
+    {
+      "name": "Peter A. Shevtsov",
+      "email": "petr.shevtsov@gmail.com"
+    },
+    {
+      "name": "Alain Kalker",
+      "email": "a.c.kalker@gmail.com"
+    },
+    {
+      "name": "Bryant Williams",
+      "email": "b.n.williams@gmail.com"
+    },
+    {
+      "name": "Jonas Weber",
+      "email": "github@jonasw.de"
+    },
+    {
+      "name": "Tim Whidden",
+      "email": "twhid@twhid.com"
+    },
+    {
+      "name": "Andreas",
+      "email": "functino@users.noreply.github.com"
+    },
+    {
+      "name": "Karolis Narkevicius",
+      "email": "karolis.n@gmail.com"
+    },
+    {
+      "name": "Adrian Lynch",
+      "email": "adi_ady_ade@hotmail.com"
+    },
+    {
+      "name": "Richard Littauer",
+      "email": "richard.littauer@gmail.com"
+    },
+    {
+      "name": "Oli Evans",
+      "email": "oli@zilla.org.uk"
+    },
+    {
+      "name": "Matt Brennan",
+      "email": "mattyb1000@gmail.com"
+    },
+    {
+      "name": "Jeff Barczewski",
+      "email": "jeff.barczewski@gmail.com"
+    },
+    {
+      "name": "Danny Fritz",
+      "email": "dannyfritz@gmail.com"
+    },
+    {
+      "name": "Takaya Kobayashi",
+      "email": "jigsaw@live.jp"
+    },
+    {
+      "name": "Ra'Shaun Stovall",
+      "email": "rashaunstovall@gmail.com"
+    },
+    {
+      "name": "Julien Meddah",
+      "email": "julien.meddah@deveryware.com"
+    },
+    {
+      "name": "Michiel Sikma",
+      "email": "michiel@wedemandhtml.com"
+    },
+    {
+      "name": "Jakob Krigovsky",
+      "email": "jakob.krigovsky@gmail.com"
+    },
+    {
+      "name": "Charmander",
+      "email": "~@charmander.me"
+    },
+    {
+      "name": "Erik Wienhold",
+      "email": "git@ewie.name"
+    },
+    {
+      "name": "James Butler",
+      "email": "james.butler@sandfox.co.uk"
+    },
+    {
+      "name": "Kevin Kragenbrink",
+      "email": "kevin@gaikai.com"
+    },
+    {
+      "name": "Arnaud Rinquin",
+      "email": "rinquin.arnaud@gmail.com"
+    },
+    {
+      "name": "Mike MacCana",
+      "email": "mike.maccana@gmail.com"
+    },
+    {
+      "name": "Antti Mattila",
+      "email": "anttti@fastmail.fm"
+    },
+    {
+      "name": "laiso",
+      "email": "laiso@lai.so"
+    },
+    {
+      "name": "Matt Zorn",
+      "email": "zornme@gmail.com"
+    },
+    {
+      "name": "Kyle Mitchell",
+      "email": "kyle@kemitchell.com"
+    },
+    {
+      "name": "Jeremiah Senkpiel",
+      "email": "fishrock123@rocketmail.com"
+    },
+    {
+      "name": "Michael Klein",
+      "email": "mischkl@users.noreply.github.com"
+    },
+    {
+      "name": "Simen Bekkhus",
+      "email": "sbekkhus91@gmail.com"
+    },
+    {
+      "name": "Victor",
+      "email": "victor.shih@gmail.com"
+    },
+    {
+      "name": "thefourtheye",
+      "email": "thechargingvolcano@gmail.com"
+    },
+    {
+      "name": "Clay Carpenter",
+      "email": "claycarpenter@gmail.com"
+    },
+    {
+      "name": "bangbang93",
+      "email": "bangbang93@163.com"
+    },
+    {
+      "name": "Nick Malaguti",
+      "email": "nmalaguti@palantir.com"
+    },
+    {
+      "name": "Cedric Nelson",
+      "email": "cedric.nelson@gmail.com"
+    },
+    {
+      "name": "Kat Marchán",
+      "email": "kzm@sykosomatic.org"
+    },
+    {
+      "name": "Andrew",
+      "email": "talktome@aboutandrew.co.uk"
+    },
+    {
+      "name": "Eduardo Pinho",
+      "email": "enet4mikeenet@gmail.com"
+    },
+    {
+      "name": "Rachel Hutchison",
+      "email": "rhutchix@intel.com"
+    },
+    {
+      "name": "Ryan Temple",
+      "email": "ryantemple145@gmail.com"
+    },
+    {
+      "name": "Eugene Sharygin",
+      "email": "eush77@gmail.com"
+    },
+    {
+      "name": "James Talmage",
+      "email": "james@talmage.io"
+    },
+    {
+      "name": "jane arc",
+      "email": "jane@uber.com"
+    },
+    {
+      "name": "Joseph Dykstra",
+      "email": "josephdykstra@gmail.com"
+    },
+    {
+      "name": "Andrew Crites",
+      "email": "ajcrites@gmail.com"
+    },
+    {
+      "name": "Joshua Egan",
+      "email": "josh-egan@users.noreply.github.com"
+    },
+    {
+      "name": "Carlos Alberto",
+      "email": "euprogramador@gmail.com"
+    },
+    {
+      "name": "Thomas Cort",
+      "email": "thomasc@ssimicro.com"
+    },
+    {
+      "name": "Thaddee Tyl",
+      "email": "thaddee.tyl@gmail.com"
+    },
+    {
+      "name": "Steve Klabnik",
+      "email": "steve@steveklabnik.com"
+    },
+    {
+      "name": "Andrew Murray",
+      "email": "radarhere@gmail.com"
+    },
+    {
+      "name": "Stephan Bönnemann",
+      "email": "stephan@excellenteasy.com"
+    },
+    {
+      "name": "Kyle M. Tarplee",
+      "email": "kyle.tarplee@numerica.us"
+    },
+    {
+      "name": "Derek Peterson",
+      "email": "derekpetey@gmail.com"
+    },
+    {
+      "name": "Greg Whiteley",
+      "email": "greg.whiteley@atomos.com"
+    },
+    {
+      "name": "murgatroid99",
+      "email": "mlumish@google.com"
+    },
+    {
+      "name": "Marcin Cieslak",
+      "email": "saper@saper.info"
+    },
+    {
+      "name": "João Reis",
+      "email": "reis@janeasystems.com"
+    },
+    {
+      "name": "Matthew Hasbach",
+      "email": "hasbach.git@gmail.com"
+    },
+    {
+      "name": "Jon Hall",
+      "email": "jon_hall@outlook.com"
+    },
+    {
+      "name": "Anna Henningsen",
+      "email": "sqrt@entless.org"
+    },
+    {
+      "name": "James Treworgy",
+      "email": "jamietre@gmail.com"
+    },
+    {
+      "name": "James Hartig",
+      "email": "james@levenlabs.com"
+    },
+    {
+      "name": "Stephanie Snopek",
+      "email": "stephaniesnopek@gmail.com"
+    },
+    {
+      "name": "Kent C. Dodds",
+      "email": "kent@doddsfamily.us"
+    },
+    {
+      "name": "Aaron Krause",
+      "email": "aaronjkrause@gmail.com"
+    },
+    {
+      "name": "Daniel K O'Leary",
+      "email": "daniel@dko.io"
+    },
+    {
+      "name": "fscherwi",
+      "email": "fscherwi@users.noreply.github.com"
+    },
+    {
+      "name": "Thomas Reggi",
+      "email": "thomas@reggi.com"
+    },
+    {
+      "name": "Thomas Michael McTiernan",
+      "email": "thomasmctiernan@gmail.com"
+    },
+    {
+      "name": "Jason Kurian",
+      "email": "JaKXz@users.noreply.github.com"
+    },
+    {
+      "name": "Sebastiaan Deckers",
+      "email": "seb@ninja.sg"
+    },
+    {
+      "name": "lady3bean",
+      "email": "lady3bean@users.noreply.github.com"
+    },
+    {
+      "name": "Tomi Carr",
+      "email": "TaMe3971@users.noreply.github.com"
+    },
+    {
+      "name": "Juan Caicedo",
+      "email": "retiredcanadianpoet@gmail.com"
+    },
+    {
+      "name": "Ashley Williams",
+      "email": "ashley@npmjs.com"
+    },
+    {
+      "name": "Andrew Marcinkevičius",
+      "email": "andrew.web@ifdattic.com"
+    },
+    {
+      "name": "Jorrit Schippers",
+      "email": "jorrit@ncode.nl"
+    },
+    {
+      "name": "Alex Lukin",
+      "email": "alex.lukin@softgrad.com"
+    },
+    {
+      "name": "Aria Stewart",
+      "email": "aredridel@dinhe.net"
+    },
+    {
+      "name": "Tiago Rodrigues",
+      "email": "tmcrodrigues@gmail.com"
+    },
+    {
+      "name": "Tim",
+      "email": "tim-github@baverstock.org.uk"
+    },
+    {
+      "name": "Nick Williams",
+      "email": "WickyNilliams@users.noreply.github.com"
+    },
+    {
+      "name": "Louis Larry",
+      "email": "louis.larry@gmail.com"
+    },
+    {
+      "name": "Ben Gotow",
+      "email": "bengotow@gmail.com"
+    },
+    {
+      "name": "Jakub Gieryluk",
+      "email": "jakub.g.opensource@gmail.com"
+    },
+    {
+      "name": "Kevin Lorenz",
+      "email": "mail@kevinlorenz.com"
+    },
+    {
+      "name": "Martin von Gagern",
+      "email": "Martin.vGagern@gmx.net"
+    },
+    {
+      "name": "Eymen Gunay",
+      "email": "eymen@egunay.com"
+    },
+    {
+      "name": "Martin Ek",
+      "email": "mail@ekmartin.com"
+    },
+    {
+      "name": "Rafał Pocztarski",
+      "email": "r.pocztarski@gmail.com"
+    },
+    {
+      "name": "Mark Reeder",
+      "email": "mreeder@uber.com"
+    },
+    {
+      "name": "Chris Rebert",
+      "email": "github@chrisrebert.com"
+    },
+    {
+      "name": "Scott Addie",
+      "email": "tobias.addie@gmail.com"
+    },
+    {
+      "name": "Jeff McMahan",
+      "email": "jeffrey.lee.mcmahan@gmail.com"
+    },
+    {
+      "name": "Tim Krins",
+      "email": "timkrins@gmail.com"
+    },
+    {
+      "name": "Hal Henke",
+      "email": "halhenke@gmail.com"
+    },
+    {
+      "name": "Julian Simioni",
+      "email": "julian@simioni.org"
+    },
+    {
+      "name": "Jimb Esser",
+      "email": "jimb@yahoo-inc.com"
+    },
+    {
+      "name": "Alexis Campailla",
+      "email": "alexis@janeasystems.com"
+    },
+    {
+      "name": "Chris Chua",
+      "email": "chris.sirhc@gmail.com"
+    },
+    {
+      "name": "Beau Gunderson",
+      "email": "beau@beaugunderson.com"
+    },
+    {
+      "name": "Dave Galbraith",
+      "email": "dave@jut.io"
+    },
+    {
+      "name": "s100",
+      "email": "shughes1@uk.ibm.com"
+    },
+    {
+      "name": "Sergey Simonchik",
+      "email": "sergey.simonchik@jetbrains.com"
+    },
+    {
+      "name": "Vanja Radovanović",
+      "email": "elvanja@gmail.com"
+    },
+    {
+      "name": "Jonathan Persson",
+      "email": "persson.jonathan@gmail.com"
+    },
+    {
+      "name": "Vedat Mahir YILMAZ",
+      "email": "mahir@vedatmahir.com"
+    },
+    {
+      "name": "Samuel Reed",
+      "email": "samuel.trace.reed@gmail.com"
+    },
+    {
+      "name": "Rafał Legiędź",
+      "email": "rafal.legiedz@gmail.com"
+    },
+    {
+      "name": "Jan Schär",
+      "email": "jscissr@gmail.com"
+    },
+    {
+      "name": "Xcat Liu",
+      "email": "xcatliu@gmail.com"
+    },
+    {
+      "name": "harryh",
+      "email": "Aourin@users.noreply.github.com"
+    },
+    {
+      "name": "Prayag Verma",
+      "email": "prayag.verma@gmail.com"
+    },
+    {
+      "name": "Neil Kistner",
+      "email": "neil.kistner@gmail.com"
+    },
+    {
+      "name": "Zoujie Wzj",
+      "email": "zoujie.wzj@alibaba-inc.com"
+    },
+    {
+      "name": "Ryan Hendrickson",
+      "email": "ryan.hendrickson@alum.mit.edu"
+    },
+    {
+      "name": "Arturo Coronel",
+      "email": "aoitsu3@gmail.com"
+    },
+    {
+      "name": "Hutson Betts",
+      "email": "hbetts@factset.com"
+    },
+    {
+      "name": "Lewis Cowper",
+      "email": "lewis.cowper@googlemail.com"
+    },
+    {
+      "name": "Adam Byrne",
+      "email": "misterbyrne@gmail.com"
+    },
+    {
+      "name": "Ifeanyi Oraelosi",
+      "email": "ifeanyioraelosi@gmail.com"
+    },
+    {
+      "name": "Robert Ludwig",
+      "email": "rob.ludwig@rideamigos.com"
+    },
+    {
+      "name": "Chris Warren",
+      "email": "chris@ixalon.net"
+    },
+    {
+      "name": "Scott Plumlee",
+      "email": "scott@plumlee.org"
+    },
+    {
+      "name": "Daniel Pedersen",
+      "email": "daniel@scandinav.se"
+    },
+    {
+      "name": "rhgb",
+      "email": "kaiserdaemon@gmail.com"
+    },
+    {
+      "name": "doug.wade",
+      "email": "doug.wade@redfin.com"
+    },
+    {
+      "name": "Zac",
+      "email": "zdoege@gm.slc.edu"
+    },
+    {
+      "name": "GriffinSchneider",
+      "email": "griffinschneider@gmail.com"
+    },
+    {
+      "name": "Andres Kalle",
+      "email": "mjomble@gmail.com"
+    },
+    {
+      "name": "thefourtheye",
+      "email": "thefourtheye@users.noreply.github.com"
+    },
+    {
+      "name": "Yael",
+      "email": "yaelz@users.noreply.github.com"
+    },
+    {
+      "name": "Yann Odeyer",
+      "email": "yann@odeyer.com"
+    },
+    {
+      "name": "James Monger",
+      "email": "jameskmonger@hotmail.co.uk"
+    },
+    {
+      "name": "Thomas Hallock",
+      "email": "thomas@1stdibs.com"
+    },
+    {
+      "name": "Paul Irish",
+      "email": "paul.irish@gmail.com"
+    },
+    {
+      "name": "Paul O'Leary McCann",
+      "email": "polm@dampfkraft.com"
+    },
+    {
+      "name": "Francis Gulotta",
+      "email": "wizard@roborooter.com"
+    },
+    {
+      "name": "Felix Rieseberg",
+      "email": "felix@felixrieseberg.com"
+    },
+    {
+      "name": "Glen Mailer",
+      "email": "glenjamin@gmail.com"
+    },
+    {
+      "name": "Federico Brigante",
+      "email": "bfred-it@users.noreply.github.com"
+    },
+    {
+      "name": "Steve Mao",
+      "email": "maochenyan@gmail.com"
+    },
+    {
+      "name": "Anna Henningsen",
+      "email": "anna@addaleax.net"
+    },
+    {
+      "name": "Rachel Evans",
+      "email": "git@rve.org.uk"
+    },
+    {
+      "name": "Sam Minnee",
+      "email": "sam@silverstripe.com"
+    },
+    {
+      "name": "Zirak",
+      "email": "zirakertan@gmail.com"
+    },
+    {
+      "name": "Daniel Lupu",
+      "email": "lupu.daniel.f@gmail.com"
+    },
+    {
+      "name": "Gianluca Casati",
+      "email": "fibo@users.noreply.github.com"
+    },
+    {
+      "name": "André Herculano",
+      "email": "andresilveirah@gmail.com"
+    },
+    {
+      "name": "Wyatt Preul",
+      "email": "wpreul@gmail.com"
+    },
+    {
+      "name": "Myles Borins",
+      "email": "mborins@us.ibm.com"
+    },
+    {
+      "name": "Elliot Lee",
+      "email": "github.public@intelliot.com"
+    },
+    {
+      "name": "Dmitry Kirilyuk",
+      "email": "gk.joker@gmail.com"
+    },
+    {
+      "name": "Aaron Tribou",
+      "email": "aaron.tribou@gmail.com"
+    },
+    {
+      "name": "Tapani Moilanen",
+      "email": "moilanen.tapani@gmail.com"
+    },
+    {
+      "name": "Han Seoul-Oh",
+      "email": "laughinghan@gmail.com"
+    },
+    {
+      "name": "Aleksey Shvayka",
+      "email": "shvaikalesh@gmail.com"
+    },
+    {
+      "name": "Emma Ramirez",
+      "email": "ramirez.emma.g@gmail.com"
+    },
+    {
+      "name": "Julian Duque",
+      "email": "julianduquej@gmail.com"
+    },
+    {
+      "name": "Simon MacDonald",
+      "email": "simon.macdonald@gmail.com"
+    },
+    {
+      "name": "Adam Stankiewicz",
+      "email": "sheerun@sher.pl"
+    },
+    {
+      "name": "Gregers Gram Rygg",
+      "email": "gregers.gram.rygg@finn.no"
+    },
+    {
+      "name": "Peter Dave Hello",
+      "email": "hsu@peterdavehello.org"
+    },
+    {
+      "name": "Jordan Klassen",
+      "email": "forivall@gmail.com"
+    },
+    {
+      "name": "Jason Palmer",
+      "email": "jason@jason-palmer.com"
+    },
+    {
+      "name": "Michael Hart",
+      "email": "michael.hart.au@gmail.com"
+    },
+    {
+      "name": "Sasha Koss",
+      "email": "koss@nocorp.me"
+    },
+    {
+      "name": "David Emmerson",
+      "email": "david.emmerson@gmail.com"
+    },
+    {
+      "name": "Christophe Hurpeau",
+      "email": "christophe@hurpeau.com"
+    },
+    {
+      "name": "Daniel Paz-Soldan",
+      "email": "daniel.pazsoldan@gmail.com"
+    },
+    {
+      "name": "Sakthipriyan Vairamani",
+      "email": "thechargingvolcano@gmail.com"
+    },
+    {
+      "name": "Zach Renner",
+      "email": "zarenner@microsoft.com"
+    },
+    {
+      "name": "Christopher Hiller",
+      "email": "boneskull@boneskull.com"
+    },
+    {
+      "name": "legodude17",
+      "email": "legodudejb@gmail.com"
+    },
+    {
+      "name": "Andrew Meyer",
+      "email": "andrewm.bpi@gmail.com"
+    },
+    {
+      "name": "Michael Jasper",
+      "email": "mdjasper@gmail.com"
+    },
+    {
+      "name": "Max",
+      "email": "contact@mstoiber.com"
+    },
+    {
+      "name": "Szymon Nowak",
+      "email": "szimek@gmail.com"
+    },
+    {
+      "name": "Jason Karns",
+      "email": "jason.karns@gmail.com"
+    },
+    {
+      "name": "Lucas Holmquist",
+      "email": "lholmqui@redhat.com"
+    },
+    {
+      "name": "Ionică Bizău",
+      "email": "bizauionica@gmail.com"
+    },
+    {
+      "name": "Alex Chesters",
+      "email": "AlexChesters@users.noreply.github.com"
+    },
+    {
+      "name": "Robert Gay",
+      "email": "robert.gay@redfin.com"
+    },
+    {
+      "name": "Steven",
+      "email": "stevokk@hotmail.com"
+    }
+  ],
+  "readme": "npm(1) -- a JavaScript package manager\n==============================\n[![Build Status](https://img.shields.io/travis/npm/npm/master.svg)](https://travis-ci.org/npm/npm)\n## SYNOPSIS\n\nThis is just enough info to get you up and running.\n\nMuch more info available via `npm help` once it's installed.\n\n## IMPORTANT\n\n**You need node v0.10 or higher to run this program.**\n\nTo install an old **and unsupported** version of npm that works on node 0.3\nand prior, clone the git repo and dig through the old tags and branches.\n\n**npm is configured to use npm, Inc.'s public package registry at\n<https://registry.npmjs.org> by default.**\n\nYou can configure npm to use any compatible registry you\nlike, and even run your own registry. Check out the [doc on\nregistries](https://docs.npmjs.com/misc/registry).\n\nUse of someone else's registry may be governed by terms of use. The\nterms of use for the default public registry are available at\n<https://www.npmjs.com>.\n\n## Super Easy Install\n\nnpm is bundled with [node](http://nodejs.org/download/).\n\n### Windows Computers\n\n[Get the MSI](http://nodejs.org/download/).  npm is in it.\n\n### Apple Macintosh Computers\n\n[Get the pkg](http://nodejs.org/download/).  npm is in it.\n\n### Other Sorts of Unices\n\nRun `make install`.  npm will be installed with node.\n\nIf you want a more fancy pants install (a different version, customized\npaths, etc.) then read on.\n\n## Fancy Install (Unix)\n\nThere's a pretty robust install script at\n<https://www.npmjs.com/install.sh>.  You can download that and run it.\n\nHere's an example using curl:\n\n```sh\ncurl -L https://www.npmjs.com/install.sh | sh\n```\n\n### Slightly Fancier\n\nYou can set any npm configuration params with that script:\n\n```sh\nnpm_config_prefix=/some/path sh install.sh\n```\n\nOr, you can run it in uber-debuggery mode:\n\n```sh\nnpm_debug=1 sh install.sh\n```\n\n### Even Fancier\n\nGet the code with git.  Use `make` to build the docs and do other stuff.\nIf you plan on hacking on npm, `make link` is your friend.\n\nIf you've got the npm source code, you can also semi-permanently set\narbitrary config keys using the `./configure --key=val ...`, and then\nrun npm commands by doing `node cli.js <cmd> <args>`.  (This is helpful\nfor testing, or running stuff without actually installing npm itself.)\n\n## Windows Install or Upgrade\n\nMany improvements for Windows users have been made in npm 3 - you will have a better\nexperience if you run a recent version of npm. To upgrade, either use [Microsoft's\nupgrade tool](https://github.com/felixrieseberg/npm-windows-upgrade),\n[download a new version of Node](http://nodejs.org/download/),\nor follow the Windows upgrade instructions in the\n[npm Troubleshooting Guide](https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows).\n\nIf that's not fancy enough for you, then you can fetch the code with\ngit, and mess with it directly.\n\n## Installing on Cygwin\n\nNo.\n\n## Uninstalling\n\nSo sad to see you go.\n\n```sh\nsudo npm uninstall npm -g\n```\nOr, if that fails,\n\n```sh\nsudo make uninstall\n```\n\n## More Severe Uninstalling\n\nUsually, the above instructions are sufficient.  That will remove\nnpm, but leave behind anything you've installed.\n\nIf you would like to remove all the packages that you have installed,\nthen you can use the `npm ls` command to find them, and then `npm rm` to\nremove them.\n\nTo remove cruft left behind by npm 0.x, you can use the included\n`clean-old.sh` script file.  You can run it conveniently like this:\n\n```sh\nnpm explore npm -g -- sh scripts/clean-old.sh\n```\n\nnpm uses two configuration files, one for per-user configs, and another\nfor global (every-user) configs.  You can view them by doing:\n\n```sh\nnpm config get userconfig   # defaults to ~/.npmrc\nnpm config get globalconfig # defaults to /usr/local/etc/npmrc\n```\n\nUninstalling npm does not remove configuration files by default.  You\nmust remove them yourself manually if you want them gone.  Note that\nthis means that future npm installs will not remember the settings that\nyou have chosen.\n\n## More Docs\n\nCheck out the [docs](https://docs.npmjs.com/),\n\nYou can use the `npm help` command to read any of them.\n\nIf you're a developer, and you want to use npm to publish your program,\nyou should [read this](https://docs.npmjs.com/misc/developers)\n\n## BUGS\n\nWhen you find issues, please report them:\n\n* web:\n  <https://github.com/npm/npm/issues>\n\nBe sure to include *all* of the output from the npm command that didn't work\nas expected.  The `npm-debug.log` file is also helpful to provide.\n\nYou can also look for isaacs in #node.js on irc://irc.freenode.net.  He\nwill no doubt tell you to put the output in a gist or email.\n\n## SEE ALSO\n\n* npm(1)\n* npm-help(1)\n* npm-index(7)\n",
+  "readmeFilename": "README.md",
+  "_id": "npm@3.10.10",
+  "_shasum": "1077b6290364cf16b77970f0aa81f51b3203230e",
+  "_resolved": "https://github.com/npm/npm/archive/v3.10.10.tar.gz",
+  "_from": "https://github.com/npm/npm/archive/v3.10.10.tar.gz"
+}

--- a/test/fixtures/tarball-fail-version/package.json
+++ b/test/fixtures/tarball-fail-version/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tarball-fail",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "npm": "https://github.com/npm/npm/archive/v4.1.2.tar.gz"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/test/fixtures/tarball-pass/index.js
+++ b/test/fixtures/tarball-pass/index.js
@@ -1,0 +1,1 @@
+require('npm');

--- a/test/fixtures/tarball-pass/node_modules/npm/package.json
+++ b/test/fixtures/tarball-pass/node_modules/npm/package.json
@@ -1,0 +1,2036 @@
+{
+  "version": "4.1.2",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "keywords": [
+    "install",
+    "modules",
+    "package manager",
+    "package.json"
+  ],
+  "preferGlobal": true,
+  "config": {
+    "publishtest": false
+  },
+  "homepage": "https://docs.npmjs.com/",
+  "author": {
+    "name": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/npm.git"
+  },
+  "bugs": {
+    "url": "https://github.com/npm/npm/issues"
+  },
+  "directories": {
+    "bin": "./bin",
+    "doc": "./doc",
+    "lib": "./lib",
+    "man": "./man"
+  },
+  "main": "./lib/npm.js",
+  "bin": {
+    "npm": "./bin/npm-cli.js"
+  },
+  "dependencies": {
+    "JSONStream": "~1.3.0",
+    "abbrev": "~1.0.9",
+    "ansicolors": "~0.3.2",
+    "ansistyles": "~0.1.3",
+    "aproba": "~1.0.4",
+    "archy": "~1.0.0",
+    "asap": "~2.0.5",
+    "chownr": "~1.0.1",
+    "cmd-shim": "~2.0.2",
+    "columnify": "~1.5.4",
+    "config-chain": "~1.1.11",
+    "dezalgo": "~1.0.3",
+    "editor": "~1.0.0",
+    "fs-vacuum": "~1.2.9",
+    "fs-write-stream-atomic": "~1.0.8",
+    "fstream": "~1.0.10",
+    "fstream-npm": "~1.2.0",
+    "glob": "~7.1.1",
+    "graceful-fs": "~4.1.11",
+    "has-unicode": "~2.0.1",
+    "hosted-git-info": "~2.1.5",
+    "iferr": "~0.1.5",
+    "inflight": "~1.0.6",
+    "inherits": "~2.0.3",
+    "ini": "~1.3.4",
+    "init-package-json": "~1.9.4",
+    "lockfile": "~1.0.3",
+    "lodash._baseuniq": "~4.6.0",
+    "lodash.clonedeep": "~4.5.0",
+    "lodash.union": "~4.6.0",
+    "lodash.uniq": "~4.5.0",
+    "lodash.without": "~4.4.0",
+    "mississippi": "~1.2.0",
+    "mkdirp": "~0.5.1",
+    "node-gyp": "~3.5.0",
+    "nopt": "~4.0.1",
+    "normalize-git-url": "~3.0.2",
+    "normalize-package-data": "~2.3.5",
+    "npm-cache-filename": "~1.0.2",
+    "npm-install-checks": "~3.0.0",
+    "npm-package-arg": "~4.2.0",
+    "npm-registry-client": "~7.4.5",
+    "npm-user-validate": "~0.1.5",
+    "npmlog": "~4.0.2",
+    "once": "~1.4.0",
+    "opener": "~1.4.2",
+    "osenv": "~0.1.4",
+    "path-is-inside": "~1.0.2",
+    "read": "~1.0.7",
+    "read-cmd-shim": "~1.0.1",
+    "read-installed": "~4.0.3",
+    "read-package-json": "~2.0.4",
+    "read-package-tree": "~5.1.5",
+    "readable-stream": "~2.2.2",
+    "realize-package-specifier": "~3.0.3",
+    "request": "~2.79.0",
+    "retry": "~0.10.1",
+    "rimraf": "~2.5.4",
+    "semver": "~5.3.0",
+    "sha": "~2.0.1",
+    "slide": "~1.1.6",
+    "sorted-object": "~2.0.1",
+    "sorted-union-stream": "~2.1.3",
+    "strip-ansi": "~3.0.1",
+    "tar": "~2.2.1",
+    "text-table": "~0.2.0",
+    "uid-number": "0.0.6",
+    "umask": "~1.1.0",
+    "unique-filename": "~1.1.0",
+    "unpipe": "~1.0.0",
+    "uuid": "~3.0.1",
+    "validate-npm-package-name": "~2.2.2",
+    "which": "~1.2.12",
+    "wrappy": "~1.0.2",
+    "write-file-atomic": "~1.3.1",
+    "ansi-regex": "*",
+    "debuglog": "*",
+    "imurmurhash": "*",
+    "lodash._baseindexof": "*",
+    "lodash._bindcallback": "*",
+    "lodash._cacheindexof": "*",
+    "lodash._createcache": "*",
+    "lodash._getnative": "*",
+    "lodash.restparam": "*",
+    "readdir-scoped-modules": "*",
+    "validate-npm-package-license": "*"
+  },
+  "bundleDependencies": [
+    "abbrev",
+    "ansi-regex",
+    "ansicolors",
+    "ansistyles",
+    "aproba",
+    "archy",
+    "asap",
+    "chownr",
+    "cmd-shim",
+    "columnify",
+    "config-chain",
+    "debuglog",
+    "dezalgo",
+    "editor",
+    "fs-vacuum",
+    "fs-write-stream-atomic",
+    "fstream",
+    "fstream-npm",
+    "glob",
+    "graceful-fs",
+    "has-unicode",
+    "hosted-git-info",
+    "iferr",
+    "imurmurhash",
+    "inflight",
+    "inherits",
+    "ini",
+    "init-package-json",
+    "JSONStream",
+    "lockfile",
+    "lodash._baseindexof",
+    "lodash._baseuniq",
+    "lodash._bindcallback",
+    "lodash._cacheindexof",
+    "lodash._createcache",
+    "lodash._getnative",
+    "lodash.clonedeep",
+    "lodash.restparam",
+    "lodash.union",
+    "lodash.uniq",
+    "lodash.without",
+    "mkdirp",
+    "node-gyp",
+    "nopt",
+    "normalize-git-url",
+    "normalize-package-data",
+    "npm-cache-filename",
+    "npm-install-checks",
+    "npm-package-arg",
+    "npm-registry-client",
+    "npm-user-validate",
+    "npmlog",
+    "once",
+    "opener",
+    "osenv",
+    "path-is-inside",
+    "read",
+    "read-cmd-shim",
+    "read-installed",
+    "read-package-json",
+    "read-package-tree",
+    "readable-stream",
+    "readdir-scoped-modules",
+    "realize-package-specifier",
+    "request",
+    "retry",
+    "rimraf",
+    "semver",
+    "sha",
+    "slide",
+    "sorted-object",
+    "sorted-union-stream",
+    "strip-ansi",
+    "tar",
+    "text-table",
+    "uid-number",
+    "umask",
+    "unique-filename",
+    "unpipe",
+    "validate-npm-package-license",
+    "validate-npm-package-name",
+    "which",
+    "wrappy",
+    "write-file-atomic",
+    "mississippi",
+    "uuid"
+  ],
+  "devDependencies": {
+    "deep-equal": "~1.0.1",
+    "marked": "~0.3.6",
+    "marked-man": "~0.2.0",
+    "npm-registry-couchapp": "~2.6.12",
+    "npm-registry-mock": "~1.0.1",
+    "require-inject": "~1.4.0",
+    "sprintf-js": "~1.0.3",
+    "standard": "~6.0.8",
+    "tacks": "~1.2.2",
+    "tap": "~9.0.3"
+  },
+  "scripts": {
+    "dumpconf": "env | grep npm | sort | uniq",
+    "prepublish": "node bin/npm-cli.js prune --prefix=. --no-global && rimraf test/*/*/node_modules && make doc-clean && make -j4 doc",
+    "preversion": "bash scripts/update-authors.sh && git add AUTHORS && git commit -m \"update AUTHORS\" || true",
+    "tap": "tap --timeout 300",
+    "tap-cover": "tap --nyc-arg='--cache' --coverage --timeout 600",
+    "test": "standard && npm run test-tap",
+    "test-coverage": "npm run tap-cover -- \"test/tap/*.js\" \"test/network/*.js\" \"test/broken-under-*/*.js\"",
+    "test-tap": "npm run tap -- \"test/tap/*.js\" \"test/network/*.js\" \"test/broken-under-*/*.js\"",
+    "test-node": "tap --timeout 240 \"test/tap/*.js\" \"test/network/*.js\" \"test/broken-under-nyc*/*.js\""
+  },
+  "license": "Artistic-2.0",
+  "man": [],
+  "contributors": [
+    {
+      "name": "Isaac Z. Schlueter",
+      "email": "i@izs.me"
+    },
+    {
+      "name": "Steve Steiner",
+      "email": "ssteinerX@gmail.com"
+    },
+    {
+      "name": "Mikeal Rogers",
+      "email": "mikeal.rogers@gmail.com"
+    },
+    {
+      "name": "Aaron Blohowiak",
+      "email": "aaron.blohowiak@gmail.com"
+    },
+    {
+      "name": "Martyn Smith",
+      "email": "martyn@dollyfish.net.nz"
+    },
+    {
+      "name": "Charlie Robbins",
+      "email": "charlie.robbins@gmail.com"
+    },
+    {
+      "name": "Francisco Treacy",
+      "email": "francisco.treacy@gmail.com"
+    },
+    {
+      "name": "Cliffano Subagio",
+      "email": "cliffano@gmail.com"
+    },
+    {
+      "name": "Christian Eager",
+      "email": "christian.eager@nokia.com"
+    },
+    {
+      "name": "Dav Glass",
+      "email": "davglass@gmail.com"
+    },
+    {
+      "name": "Alex K. Wolfe",
+      "email": "alexkwolfe@gmail.com"
+    },
+    {
+      "name": "James Sanders",
+      "email": "jimmyjazz14@gmail.com"
+    },
+    {
+      "name": "Reid Burke",
+      "email": "me@reidburke.com"
+    },
+    {
+      "name": "Arlo Breault",
+      "email": "arlolra@gmail.com"
+    },
+    {
+      "name": "Timo Derstappen",
+      "email": "teemow@gmail.com"
+    },
+    {
+      "name": "Bart Teeuwisse",
+      "email": "bart.teeuwisse@thecodemill.biz"
+    },
+    {
+      "name": "Ben Noordhuis",
+      "email": "info@bnoordhuis.nl"
+    },
+    {
+      "name": "Tor Valamo",
+      "email": "tor.valamo@gmail.com"
+    },
+    {
+      "name": "Whyme.Lyu",
+      "email": "5longluna@gmail.com"
+    },
+    {
+      "name": "Olivier Melcher",
+      "email": "olivier.melcher@gmail.com"
+    },
+    {
+      "name": "Tomaž Muraus",
+      "email": "kami@k5-storitve.net"
+    },
+    {
+      "name": "Evan Meagher",
+      "email": "evan.meagher@gmail.com"
+    },
+    {
+      "name": "Orlando Vazquez",
+      "email": "ovazquez@gmail.com"
+    },
+    {
+      "name": "Kai Chen",
+      "email": "kaichenxyz@gmail.com"
+    },
+    {
+      "name": "George Miroshnykov",
+      "email": "gmiroshnykov@lohika.com"
+    },
+    {
+      "name": "Geoff Flarity",
+      "email": "geoff.flarity@gmail.com"
+    },
+    {
+      "name": "Max Goodman",
+      "email": "c@chromakode.com"
+    },
+    {
+      "name": "Pete Kruckenberg",
+      "email": "pete@kruckenberg.com"
+    },
+    {
+      "name": "Laurie Harper",
+      "email": "laurie@holoweb.net"
+    },
+    {
+      "name": "Chris Wong",
+      "email": "chris@chriswongstudio.com"
+    },
+    {
+      "name": "Scott Bronson",
+      "email": "brons_github@rinspin.com"
+    },
+    {
+      "name": "Federico Romero",
+      "email": "federomero@gmail.com"
+    },
+    {
+      "name": "Visnu Pitiyanuvath",
+      "email": "visnupx@gmail.com"
+    },
+    {
+      "name": "Irakli Gozalishvili",
+      "email": "rfobic@gmail.com"
+    },
+    {
+      "name": "Mark Cahill",
+      "email": "mark@tiemonster.info"
+    },
+    {
+      "name": "Tony",
+      "email": "zearin@gonk.net"
+    },
+    {
+      "name": "Iain Sproat",
+      "email": "iainsproat@gmail.com"
+    },
+    {
+      "name": "Trent Mick",
+      "email": "trentm@gmail.com"
+    },
+    {
+      "name": "Felix Geisendörfer",
+      "email": "felix@debuggable.com"
+    },
+    {
+      "name": "Jameson Little",
+      "email": "t.jameson.little@gmail.com"
+    },
+    {
+      "name": "Conny Brunnkvist",
+      "email": "conny@fuchsia.se"
+    },
+    {
+      "name": "Will Elwood",
+      "email": "w.elwood08@gmail.com"
+    },
+    {
+      "name": "Dean Landolt",
+      "email": "dean@deanlandolt.com"
+    },
+    {
+      "name": "Oleg Efimov",
+      "email": "efimovov@gmail.com"
+    },
+    {
+      "name": "Martin Cooper",
+      "email": "mfncooper@gmail.com"
+    },
+    {
+      "name": "Jann Horn",
+      "email": "jannhorn@googlemail.com"
+    },
+    {
+      "name": "Andrew Bradley",
+      "email": "cspotcode@gmail.com"
+    },
+    {
+      "name": "Maciej Małecki",
+      "email": "me@mmalecki.com"
+    },
+    {
+      "name": "Stephen Sugden",
+      "email": "glurgle@gmail.com"
+    },
+    {
+      "name": "Michael Budde",
+      "email": "mbudde@gmail.com"
+    },
+    {
+      "name": "Jason Smith",
+      "email": "jhs@iriscouch.com"
+    },
+    {
+      "name": "Gautham Pai",
+      "email": "buzypi@gmail.com"
+    },
+    {
+      "name": "David Trejo",
+      "email": "david.daniel.trejo@gmail.com"
+    },
+    {
+      "name": "Paul Vorbach",
+      "email": "paul@vorb.de"
+    },
+    {
+      "name": "George Ornbo",
+      "email": "george@shapeshed.com"
+    },
+    {
+      "name": "Tim Oxley",
+      "email": "secoif@gmail.com"
+    },
+    {
+      "name": "Tyler Green",
+      "email": "tyler.green2@gmail.com"
+    },
+    {
+      "name": "Dave Pacheco",
+      "email": "dap@joyent.com"
+    },
+    {
+      "name": "Danila Gerasimov",
+      "email": "danila.gerasimov@gmail.com"
+    },
+    {
+      "name": "Rod Vagg",
+      "email": "rod@vagg.org"
+    },
+    {
+      "name": "Christian Howe",
+      "email": "coderarity@gmail.com"
+    },
+    {
+      "name": "Andrew Lunny",
+      "email": "alunny@gmail.com"
+    },
+    {
+      "name": "Henrik Hodne",
+      "email": "dvyjones@binaryhex.com"
+    },
+    {
+      "name": "Adam Blackburn",
+      "email": "regality@gmail.com"
+    },
+    {
+      "name": "Kris Windham",
+      "email": "kriswindham@gmail.com"
+    },
+    {
+      "name": "Jens Grunert",
+      "email": "jens.grunert@gmail.com"
+    },
+    {
+      "name": "Joost-Wim Boekesteijn",
+      "email": "joost-wim@boekesteijn.nl"
+    },
+    {
+      "name": "Dalmais Maxence",
+      "email": "root@ip-10-195-202-5.ec2.internal"
+    },
+    {
+      "name": "Marcus Ekwall",
+      "email": "marcus.ekwall@gmail.com"
+    },
+    {
+      "name": "Aaron Stacy",
+      "email": "aaron.r.stacy@gmail.com"
+    },
+    {
+      "name": "Phillip Howell",
+      "email": "phowell@cothm.org"
+    },
+    {
+      "name": "Domenic Denicola",
+      "email": "domenic@domenicdenicola.com"
+    },
+    {
+      "name": "James Halliday",
+      "email": "mail@substack.net"
+    },
+    {
+      "name": "Jeremy Cantrell",
+      "email": "jmcantrell@gmail.com"
+    },
+    {
+      "name": "Ribettes",
+      "email": "patlogan29@gmail.com"
+    },
+    {
+      "name": "Don Park",
+      "email": "donpark@docuverse.com"
+    },
+    {
+      "name": "Einar Otto Stangvik",
+      "email": "einaros@gmail.com"
+    },
+    {
+      "name": "Kei Son",
+      "email": "heyacct@gmail.com"
+    },
+    {
+      "name": "Nicolas Morel",
+      "email": "marsup@gmail.com"
+    },
+    {
+      "name": "Mark Dube",
+      "email": "markisdee@gmail.com"
+    },
+    {
+      "name": "Nathan Rajlich",
+      "email": "nathan@tootallnate.net"
+    },
+    {
+      "name": "Maxim Bogushevich",
+      "email": "boga1@mail.ru"
+    },
+    {
+      "name": "Meaglin",
+      "email": "Meaglin.wasabi@gmail.com"
+    },
+    {
+      "name": "Ben Evans",
+      "email": "ben@bensbit.co.uk"
+    },
+    {
+      "name": "Nathan Zadoks",
+      "email": "nathan@nathan7.eu"
+    },
+    {
+      "name": "Brian White",
+      "email": "mscdex@mscdex.net"
+    },
+    {
+      "name": "Jed Schmidt",
+      "email": "tr@nslator.jp"
+    },
+    {
+      "name": "Ian Livingstone",
+      "email": "ianl@cs.dal.ca"
+    },
+    {
+      "name": "Patrick Pfeiffer",
+      "email": "patrick@buzzle.at"
+    },
+    {
+      "name": "Paul Miller",
+      "email": "paul@paulmillr.com"
+    },
+    {
+      "name": "Ryan Emery",
+      "email": "seebees@gmail.com"
+    },
+    {
+      "name": "Carl Lange",
+      "email": "carl@flax.ie"
+    },
+    {
+      "name": "Jan Lehnardt",
+      "email": "jan@apache.org"
+    },
+    {
+      "name": "Stuart P. Bentley",
+      "email": "stuart@testtrack4.com"
+    },
+    {
+      "name": "Johan Sköld",
+      "email": "johan@skold.cc"
+    },
+    {
+      "name": "Stuart Knightley",
+      "email": "stuart@stuartk.com"
+    },
+    {
+      "name": "Niggler",
+      "email": "nirk.niggler@gmail.com"
+    },
+    {
+      "name": "Paolo Fragomeni",
+      "email": "paolo@async.ly"
+    },
+    {
+      "name": "Jaakko Manninen",
+      "email": "jaakko@rocketpack.fi"
+    },
+    {
+      "name": "Luke Arduini",
+      "email": "luke.arduini@gmail.com"
+    },
+    {
+      "name": "Larz Conwell",
+      "email": "larz@larz-laptop.(none)",
+      "url": "none"
+    },
+    {
+      "name": "Marcel Klehr",
+      "email": "mklehr@gmx.net"
+    },
+    {
+      "name": "Robert Kowalski",
+      "email": "rok@kowalski.gd"
+    },
+    {
+      "name": "Forbes Lindesay",
+      "email": "forbes@lindesay.co.uk"
+    },
+    {
+      "name": "Vaz Allen",
+      "email": "vaz@tryptid.com"
+    },
+    {
+      "name": "Jake Verbaten",
+      "email": "raynos2@gmail.com"
+    },
+    {
+      "name": "Schabse Laks",
+      "email": "Dev@SLaks.net"
+    },
+    {
+      "name": "Florian Margaine",
+      "email": "florian@margaine.com"
+    },
+    {
+      "name": "Johan Nordberg",
+      "email": "its@johan-nordberg.com"
+    },
+    {
+      "name": "Ian Babrou",
+      "email": "ibobrik@gmail.com"
+    },
+    {
+      "name": "Di Wu",
+      "email": "dwu@palantir.com"
+    },
+    {
+      "name": "Mathias Bynens",
+      "email": "mathias@qiwi.be"
+    },
+    {
+      "name": "Matt McClure",
+      "email": "matt.mcclure@mapmyfitness.com"
+    },
+    {
+      "name": "Matt Lunn",
+      "email": "matt@mattlunn.me.uk"
+    },
+    {
+      "name": "Alexey Kreschuk",
+      "email": "akrsch@gmail.com"
+    },
+    {
+      "name": "elisee",
+      "email": "elisee@sparklin.org"
+    },
+    {
+      "name": "Robert Gieseke",
+      "email": "robert.gieseke@gmail.com"
+    },
+    {
+      "name": "François Frisch",
+      "email": "francoisfrisch@gmail.com"
+    },
+    {
+      "name": "Trevor Burnham",
+      "email": "tburnham@hubspot.com"
+    },
+    {
+      "name": "Alan Shaw",
+      "email": "alan@freestyle-developments.co.uk"
+    },
+    {
+      "name": "TJ Holowaychuk",
+      "email": "tj@vision-media.ca"
+    },
+    {
+      "name": "Nicholas Kinsey",
+      "email": "pyro@feisty.io"
+    },
+    {
+      "name": "Paulo Cesar",
+      "email": "pauloc062@gmail.com"
+    },
+    {
+      "name": "Elan Shanker",
+      "email": "elan.shanker@gmail.com"
+    },
+    {
+      "name": "Jon Spencer",
+      "email": "jon@jonspencer.ca"
+    },
+    {
+      "name": "Jason Diamond",
+      "email": "jason@diamond.name"
+    },
+    {
+      "name": "Maximilian Antoni",
+      "email": "mail@maxantoni.de"
+    },
+    {
+      "name": "Thom Blake",
+      "email": "tblake@brightroll.com"
+    },
+    {
+      "name": "Jess Martin",
+      "email": "jessmartin@gmail.com"
+    },
+    {
+      "name": "Spain Train",
+      "email": "michael.spainhower@opower.com"
+    },
+    {
+      "name": "Alex Rodionov",
+      "email": "p0deje@gmail.com"
+    },
+    {
+      "name": "Matt Colyer",
+      "email": "matt@colyer.name"
+    },
+    {
+      "name": "Evan You",
+      "email": "yyx990803@gmail.com"
+    },
+    {
+      "name": "bitspill",
+      "email": "bitspill+github@bitspill.net"
+    },
+    {
+      "name": "Gabriel Falkenberg",
+      "email": "gabriel.falkenberg@gmail.com"
+    },
+    {
+      "name": "Alexej Yaroshevich",
+      "email": "alex@qfox.ru"
+    },
+    {
+      "name": "Quim Calpe",
+      "email": "quim@kalpe.com"
+    },
+    {
+      "name": "Steve Mason",
+      "email": "stevem@brandwatch.com"
+    },
+    {
+      "name": "Wil Moore III",
+      "email": "wil.moore@wilmoore.com"
+    },
+    {
+      "name": "Sergey Belov",
+      "email": "peimei@ya.ru"
+    },
+    {
+      "name": "Tom Huang",
+      "email": "hzlhu.dargon@gmail.com"
+    },
+    {
+      "name": "CamilleM",
+      "email": "camille.moulin@alterway.fr"
+    },
+    {
+      "name": "Sébastien Santoro",
+      "email": "dereckson@espace-win.org"
+    },
+    {
+      "name": "Evan Lucas",
+      "email": "evan@btc.com"
+    },
+    {
+      "name": "Quinn Slack",
+      "email": "qslack@qslack.com"
+    },
+    {
+      "name": "Alex Kocharin",
+      "email": "alex@kocharin.ru"
+    },
+    {
+      "name": "Daniel Santiago",
+      "email": "daniel.santiago@highlevelwebs.com"
+    },
+    {
+      "name": "Denis Gladkikh",
+      "email": "outcoldman@gmail.com"
+    },
+    {
+      "name": "Andrew Horton",
+      "email": "andrew.j.horton@gmail.com"
+    },
+    {
+      "name": "Zeke Sikelianos",
+      "email": "zeke@sikelianos.com"
+    },
+    {
+      "name": "Dylan Greene",
+      "email": "dylang@gmail.com"
+    },
+    {
+      "name": "Franck Cuny",
+      "email": "franck.cuny@gmail.com"
+    },
+    {
+      "name": "Yeonghoon Park",
+      "email": "sola92@gmail.com"
+    },
+    {
+      "name": "Rafael de Oleza",
+      "email": "rafa@spotify.com"
+    },
+    {
+      "name": "Mikola Lysenko",
+      "email": "mikolalysenko@gmail.com"
+    },
+    {
+      "name": "Yazhong Liu",
+      "email": "yorkiefixer@gmail.com"
+    },
+    {
+      "name": "Neil Gentleman",
+      "email": "ngentleman@gmail.com"
+    },
+    {
+      "name": "Kris Kowal",
+      "email": "kris.kowal@cixar.com"
+    },
+    {
+      "name": "Alex Gorbatchev",
+      "email": "alex.gorbatchev@gmail.com"
+    },
+    {
+      "name": "Shawn Wildermuth",
+      "email": "shawn@wildermuth.com"
+    },
+    {
+      "name": "Wesley de Souza",
+      "email": "wesleywex@gmail.com"
+    },
+    {
+      "name": "yoyoyogi",
+      "email": "yogesh.k@gmail.com"
+    },
+    {
+      "name": "J. Tangelder",
+      "email": "j.tangelder@gmail.com"
+    },
+    {
+      "name": "Jean Lauliac",
+      "email": "jean@lauliac.com"
+    },
+    {
+      "name": "Andrey Kislyuk",
+      "email": "kislyuk@gmail.com"
+    },
+    {
+      "name": "Thorsten Lorenz",
+      "email": "thlorenz@gmx.de"
+    },
+    {
+      "name": "Julian Gruber",
+      "email": "julian@juliangruber.com"
+    },
+    {
+      "name": "Benjamin Coe",
+      "email": "bencoe@gmail.com"
+    },
+    {
+      "name": "Alex Ford",
+      "email": "Alex.Ford@CodeTunnel.com"
+    },
+    {
+      "name": "Matt Hickford",
+      "email": "matt.hickford@gmail.com"
+    },
+    {
+      "name": "Sean McGivern",
+      "email": "sean.mcgivern@rightscale.com"
+    },
+    {
+      "name": "C J Silverio",
+      "email": "ceejceej@gmail.com"
+    },
+    {
+      "name": "Robin Tweedie",
+      "email": "robin@songkick.com"
+    },
+    {
+      "name": "Miroslav Bajtoš",
+      "email": "miroslav@strongloop.com"
+    },
+    {
+      "name": "David Glasser",
+      "email": "glasser@davidglasser.net"
+    },
+    {
+      "name": "Gianluca Casati",
+      "email": "casati_gianluca@yahoo.it"
+    },
+    {
+      "name": "Forrest L Norvell",
+      "email": "ogd@aoaioxxysz.net"
+    },
+    {
+      "name": "Karsten Tinnefeld",
+      "email": "k.tinnefeld@googlemail.com"
+    },
+    {
+      "name": "Bryan Burgers",
+      "email": "bryan@burgers.io"
+    },
+    {
+      "name": "David Beitey",
+      "email": "david@davidjb.com"
+    },
+    {
+      "name": "Evan You",
+      "email": "yyou@google.com"
+    },
+    {
+      "name": "Zach Pomerantz",
+      "email": "zmp@umich.edu"
+    },
+    {
+      "name": "Chris Williams",
+      "email": "cwilliams88@gmail.com"
+    },
+    {
+      "name": "sudodoki",
+      "email": "smd.deluzion@gmail.com"
+    },
+    {
+      "name": "Mick Thompson",
+      "email": "dthompson@gmail.com"
+    },
+    {
+      "name": "Felix Rabe",
+      "email": "felix@rabe.io"
+    },
+    {
+      "name": "Michael Hayes",
+      "email": "michael@hayes.io"
+    },
+    {
+      "name": "Chris Dickinson",
+      "email": "christopher.s.dickinson@gmail.com"
+    },
+    {
+      "name": "Bradley Meck",
+      "email": "bradley.meck@gmail.com"
+    },
+    {
+      "name": "GeJ",
+      "email": "geraud@gcu.info"
+    },
+    {
+      "name": "Andrew Terris",
+      "email": "atterris@gmail.com"
+    },
+    {
+      "name": "Michael Nisi",
+      "email": "michael.nisi@gmail.com"
+    },
+    {
+      "name": "fengmk2",
+      "email": "fengmk2@gmail.com"
+    },
+    {
+      "name": "Adam Meadows",
+      "email": "adam.meadows@gmail.com"
+    },
+    {
+      "name": "Chulki Lee",
+      "email": "chulki.lee@gmail.com"
+    },
+    {
+      "name": "不四",
+      "email": "busi.hyy@taobao.com"
+    },
+    {
+      "name": "dead_horse",
+      "email": "dead_horse@qq.com"
+    },
+    {
+      "name": "Kenan Yildirim",
+      "email": "kenan@kenany.me"
+    },
+    {
+      "name": "Laurie Voss",
+      "email": "git@seldo.com"
+    },
+    {
+      "name": "Rebecca Turner",
+      "email": "me@re-becca.org"
+    },
+    {
+      "name": "Hunter Loftis",
+      "email": "hunter@hunterloftis.com"
+    },
+    {
+      "name": "Peter Richardson",
+      "email": "github@zoomy.net"
+    },
+    {
+      "name": "Jussi Kalliokoski",
+      "email": "jussi.kalliokoski@gmail.com"
+    },
+    {
+      "name": "Filip Weiss",
+      "email": "me@fiws.net"
+    },
+    {
+      "name": "Timo Weiß",
+      "email": "timoweiss@Timo-MBP.local"
+    },
+    {
+      "name": "Christopher Hiller",
+      "email": "chiller@badwing.com"
+    },
+    {
+      "name": "Jérémy Lal",
+      "email": "kapouer@melix.org"
+    },
+    {
+      "name": "Anders Janmyr",
+      "email": "anders@janmyr.com"
+    },
+    {
+      "name": "Chris Meyers",
+      "email": "chris.meyers.fsu@gmail.com"
+    },
+    {
+      "name": "Ludwig Magnusson",
+      "email": "ludwig@mediatool.com"
+    },
+    {
+      "name": "Wout Mertens",
+      "email": "Wout.Mertens@gmail.com"
+    },
+    {
+      "name": "Nick Santos",
+      "email": "nick@medium.com"
+    },
+    {
+      "name": "Terin Stock",
+      "email": "terinjokes@gmail.com"
+    },
+    {
+      "name": "Faiq Raza",
+      "email": "faiqrazarizvi@gmail.com"
+    },
+    {
+      "name": "Thomas Torp",
+      "email": "thomas@erupt.no"
+    },
+    {
+      "name": "Sam Mikes",
+      "email": "smikes@cubane.com"
+    },
+    {
+      "name": "Mat Tyndall",
+      "email": "mat.tyndall@gmail.com"
+    },
+    {
+      "name": "Tauren Mills",
+      "email": "tauren@sportzing.com"
+    },
+    {
+      "name": "Ron Martinez",
+      "email": "ramartin.net@gmail.com"
+    },
+    {
+      "name": "Kazuhito Hokamura",
+      "email": "k.hokamura@gmail.com"
+    },
+    {
+      "name": "Tristan Davies",
+      "email": "github@tristan.io"
+    },
+    {
+      "name": "David Volm",
+      "email": "david@volminator.com"
+    },
+    {
+      "name": "Lin Clark",
+      "email": "lin.w.clark@gmail.com"
+    },
+    {
+      "name": "Ben Page",
+      "email": "bpage@dewalch.com"
+    },
+    {
+      "name": "Jeff Jo",
+      "email": "jeffjo@squareup.com"
+    },
+    {
+      "name": "martinvd",
+      "email": "martinvdpub@gmail.com"
+    },
+    {
+      "name": "Mark J. Titorenko",
+      "email": "nospam-github.com@titorenko.net"
+    },
+    {
+      "name": "Oddur Sigurdsson",
+      "email": "oddurs@gmail.com"
+    },
+    {
+      "name": "Eric Mill",
+      "email": "eric@konklone.com"
+    },
+    {
+      "name": "Gabriel Barros",
+      "email": "descartavel1@gmail.com"
+    },
+    {
+      "name": "KevinSheedy",
+      "email": "kevinsheedy@gmail.com"
+    },
+    {
+      "name": "Aleksey Smolenchuk",
+      "email": "aleksey@uber.com"
+    },
+    {
+      "name": "Ed Morley",
+      "email": "emorley@mozilla.com"
+    },
+    {
+      "name": "Blaine Bublitz",
+      "email": "blaine@iceddev.com"
+    },
+    {
+      "name": "Andrey Fedorov",
+      "email": "anfedorov@gmail.com"
+    },
+    {
+      "name": "Daijiro Wachi",
+      "email": "daijiro.wachi@gmail.com"
+    },
+    {
+      "name": "Luc Thevenard",
+      "email": "lucthevenard@gmail.com"
+    },
+    {
+      "name": "Aria Stewart",
+      "email": "aredridel@nbtsc.org"
+    },
+    {
+      "name": "Charlie Rudolph",
+      "email": "charles.w.rudolph@gmail.com"
+    },
+    {
+      "name": "Vladimir Rutsky",
+      "email": "rutsky@users.noreply.github.com"
+    },
+    {
+      "name": "Isaac Murchie",
+      "email": "isaac@saucelabs.com"
+    },
+    {
+      "name": "Marcin Wosinek",
+      "email": "marcin.wosinek@gmail.com"
+    },
+    {
+      "name": "David Marr",
+      "email": "davemarr@gmail.com"
+    },
+    {
+      "name": "Bryan English",
+      "email": "bryan@bryanenglish.com"
+    },
+    {
+      "name": "Anthony Zotti",
+      "email": "amZotti@users.noreply.github.com"
+    },
+    {
+      "name": "Karl Horky",
+      "email": "karl.horky@gmail.com"
+    },
+    {
+      "name": "Jordan Harband",
+      "email": "ljharb@gmail.com"
+    },
+    {
+      "name": "Guðlaugur Stefán Egilsson",
+      "email": "gulli@kolibri.is"
+    },
+    {
+      "name": "Helge Skogly Holm",
+      "email": "helge.holm@gmail.com"
+    },
+    {
+      "name": "Peter A. Shevtsov",
+      "email": "petr.shevtsov@gmail.com"
+    },
+    {
+      "name": "Alain Kalker",
+      "email": "a.c.kalker@gmail.com"
+    },
+    {
+      "name": "Bryant Williams",
+      "email": "b.n.williams@gmail.com"
+    },
+    {
+      "name": "Jonas Weber",
+      "email": "github@jonasw.de"
+    },
+    {
+      "name": "Tim Whidden",
+      "email": "twhid@twhid.com"
+    },
+    {
+      "name": "Andreas",
+      "email": "functino@users.noreply.github.com"
+    },
+    {
+      "name": "Karolis Narkevicius",
+      "email": "karolis.n@gmail.com"
+    },
+    {
+      "name": "Adrian Lynch",
+      "email": "adi_ady_ade@hotmail.com"
+    },
+    {
+      "name": "Richard Littauer",
+      "email": "richard.littauer@gmail.com"
+    },
+    {
+      "name": "Oli Evans",
+      "email": "oli@zilla.org.uk"
+    },
+    {
+      "name": "Matt Brennan",
+      "email": "mattyb1000@gmail.com"
+    },
+    {
+      "name": "Jeff Barczewski",
+      "email": "jeff.barczewski@gmail.com"
+    },
+    {
+      "name": "Danny Fritz",
+      "email": "dannyfritz@gmail.com"
+    },
+    {
+      "name": "Takaya Kobayashi",
+      "email": "jigsaw@live.jp"
+    },
+    {
+      "name": "Ra'Shaun Stovall",
+      "email": "rashaunstovall@gmail.com"
+    },
+    {
+      "name": "Julien Meddah",
+      "email": "julien.meddah@deveryware.com"
+    },
+    {
+      "name": "Michiel Sikma",
+      "email": "michiel@wedemandhtml.com"
+    },
+    {
+      "name": "Jakob Krigovsky",
+      "email": "jakob.krigovsky@gmail.com"
+    },
+    {
+      "name": "Charmander",
+      "email": "~@charmander.me"
+    },
+    {
+      "name": "Erik Wienhold",
+      "email": "git@ewie.name"
+    },
+    {
+      "name": "James Butler",
+      "email": "james.butler@sandfox.co.uk"
+    },
+    {
+      "name": "Kevin Kragenbrink",
+      "email": "kevin@gaikai.com"
+    },
+    {
+      "name": "Arnaud Rinquin",
+      "email": "rinquin.arnaud@gmail.com"
+    },
+    {
+      "name": "Mike MacCana",
+      "email": "mike.maccana@gmail.com"
+    },
+    {
+      "name": "Antti Mattila",
+      "email": "anttti@fastmail.fm"
+    },
+    {
+      "name": "laiso",
+      "email": "laiso@lai.so"
+    },
+    {
+      "name": "Matt Zorn",
+      "email": "zornme@gmail.com"
+    },
+    {
+      "name": "Kyle Mitchell",
+      "email": "kyle@kemitchell.com"
+    },
+    {
+      "name": "Jeremiah Senkpiel",
+      "email": "fishrock123@rocketmail.com"
+    },
+    {
+      "name": "Michael Klein",
+      "email": "mischkl@users.noreply.github.com"
+    },
+    {
+      "name": "Simen Bekkhus",
+      "email": "sbekkhus91@gmail.com"
+    },
+    {
+      "name": "Victor",
+      "email": "victor.shih@gmail.com"
+    },
+    {
+      "name": "thefourtheye",
+      "email": "thechargingvolcano@gmail.com"
+    },
+    {
+      "name": "Clay Carpenter",
+      "email": "claycarpenter@gmail.com"
+    },
+    {
+      "name": "bangbang93",
+      "email": "bangbang93@163.com"
+    },
+    {
+      "name": "Nick Malaguti",
+      "email": "nmalaguti@palantir.com"
+    },
+    {
+      "name": "Cedric Nelson",
+      "email": "cedric.nelson@gmail.com"
+    },
+    {
+      "name": "Kat Marchán",
+      "email": "kzm@sykosomatic.org"
+    },
+    {
+      "name": "Andrew",
+      "email": "talktome@aboutandrew.co.uk"
+    },
+    {
+      "name": "Eduardo Pinho",
+      "email": "enet4mikeenet@gmail.com"
+    },
+    {
+      "name": "Rachel Hutchison",
+      "email": "rhutchix@intel.com"
+    },
+    {
+      "name": "Ryan Temple",
+      "email": "ryantemple145@gmail.com"
+    },
+    {
+      "name": "Eugene Sharygin",
+      "email": "eush77@gmail.com"
+    },
+    {
+      "name": "James Talmage",
+      "email": "james@talmage.io"
+    },
+    {
+      "name": "jane arc",
+      "email": "jane@uber.com"
+    },
+    {
+      "name": "Joseph Dykstra",
+      "email": "josephdykstra@gmail.com"
+    },
+    {
+      "name": "Andrew Crites",
+      "email": "ajcrites@gmail.com"
+    },
+    {
+      "name": "Joshua Egan",
+      "email": "josh-egan@users.noreply.github.com"
+    },
+    {
+      "name": "Carlos Alberto",
+      "email": "euprogramador@gmail.com"
+    },
+    {
+      "name": "Thomas Cort",
+      "email": "thomasc@ssimicro.com"
+    },
+    {
+      "name": "Thaddee Tyl",
+      "email": "thaddee.tyl@gmail.com"
+    },
+    {
+      "name": "Steve Klabnik",
+      "email": "steve@steveklabnik.com"
+    },
+    {
+      "name": "Andrew Murray",
+      "email": "radarhere@gmail.com"
+    },
+    {
+      "name": "Stephan Bönnemann",
+      "email": "stephan@excellenteasy.com"
+    },
+    {
+      "name": "Kyle M. Tarplee",
+      "email": "kyle.tarplee@numerica.us"
+    },
+    {
+      "name": "Derek Peterson",
+      "email": "derekpetey@gmail.com"
+    },
+    {
+      "name": "Greg Whiteley",
+      "email": "greg.whiteley@atomos.com"
+    },
+    {
+      "name": "murgatroid99",
+      "email": "mlumish@google.com"
+    },
+    {
+      "name": "Marcin Cieslak",
+      "email": "saper@saper.info"
+    },
+    {
+      "name": "João Reis",
+      "email": "reis@janeasystems.com"
+    },
+    {
+      "name": "Matthew Hasbach",
+      "email": "hasbach.git@gmail.com"
+    },
+    {
+      "name": "Jon Hall",
+      "email": "jon_hall@outlook.com"
+    },
+    {
+      "name": "Anna Henningsen",
+      "email": "sqrt@entless.org"
+    },
+    {
+      "name": "James Treworgy",
+      "email": "jamietre@gmail.com"
+    },
+    {
+      "name": "James Hartig",
+      "email": "james@levenlabs.com"
+    },
+    {
+      "name": "Stephanie Snopek",
+      "email": "stephaniesnopek@gmail.com"
+    },
+    {
+      "name": "Kent C. Dodds",
+      "email": "kent@doddsfamily.us"
+    },
+    {
+      "name": "Aaron Krause",
+      "email": "aaronjkrause@gmail.com"
+    },
+    {
+      "name": "Daniel K O'Leary",
+      "email": "daniel@dko.io"
+    },
+    {
+      "name": "fscherwi",
+      "email": "fscherwi@users.noreply.github.com"
+    },
+    {
+      "name": "Thomas Reggi",
+      "email": "thomas@reggi.com"
+    },
+    {
+      "name": "Thomas Michael McTiernan",
+      "email": "thomasmctiernan@gmail.com"
+    },
+    {
+      "name": "Jason Kurian",
+      "email": "JaKXz@users.noreply.github.com"
+    },
+    {
+      "name": "Sebastiaan Deckers",
+      "email": "seb@ninja.sg"
+    },
+    {
+      "name": "lady3bean",
+      "email": "lady3bean@users.noreply.github.com"
+    },
+    {
+      "name": "Tomi Carr",
+      "email": "TaMe3971@users.noreply.github.com"
+    },
+    {
+      "name": "Juan Caicedo",
+      "email": "retiredcanadianpoet@gmail.com"
+    },
+    {
+      "name": "Ashley Williams",
+      "email": "ashley@npmjs.com"
+    },
+    {
+      "name": "Andrew Marcinkevičius",
+      "email": "andrew.web@ifdattic.com"
+    },
+    {
+      "name": "Jorrit Schippers",
+      "email": "jorrit@ncode.nl"
+    },
+    {
+      "name": "Alex Lukin",
+      "email": "alex.lukin@softgrad.com"
+    },
+    {
+      "name": "Aria Stewart",
+      "email": "aredridel@dinhe.net"
+    },
+    {
+      "name": "Tiago Rodrigues",
+      "email": "tmcrodrigues@gmail.com"
+    },
+    {
+      "name": "Tim",
+      "email": "tim-github@baverstock.org.uk"
+    },
+    {
+      "name": "Nick Williams",
+      "email": "WickyNilliams@users.noreply.github.com"
+    },
+    {
+      "name": "Louis Larry",
+      "email": "louis.larry@gmail.com"
+    },
+    {
+      "name": "Ben Gotow",
+      "email": "bengotow@gmail.com"
+    },
+    {
+      "name": "Jakub Gieryluk",
+      "email": "jakub.g.opensource@gmail.com"
+    },
+    {
+      "name": "Kevin Lorenz",
+      "email": "mail@kevinlorenz.com"
+    },
+    {
+      "name": "Martin von Gagern",
+      "email": "Martin.vGagern@gmx.net"
+    },
+    {
+      "name": "Eymen Gunay",
+      "email": "eymen@egunay.com"
+    },
+    {
+      "name": "Martin Ek",
+      "email": "mail@ekmartin.com"
+    },
+    {
+      "name": "Rafał Pocztarski",
+      "email": "r.pocztarski@gmail.com"
+    },
+    {
+      "name": "Mark Reeder",
+      "email": "mreeder@uber.com"
+    },
+    {
+      "name": "Chris Rebert",
+      "email": "github@chrisrebert.com"
+    },
+    {
+      "name": "Scott Addie",
+      "email": "tobias.addie@gmail.com"
+    },
+    {
+      "name": "Jeff McMahan",
+      "email": "jeffrey.lee.mcmahan@gmail.com"
+    },
+    {
+      "name": "Tim Krins",
+      "email": "timkrins@gmail.com"
+    },
+    {
+      "name": "Hal Henke",
+      "email": "halhenke@gmail.com"
+    },
+    {
+      "name": "Julian Simioni",
+      "email": "julian@simioni.org"
+    },
+    {
+      "name": "Jimb Esser",
+      "email": "jimb@yahoo-inc.com"
+    },
+    {
+      "name": "Alexis Campailla",
+      "email": "alexis@janeasystems.com"
+    },
+    {
+      "name": "Chris Chua",
+      "email": "chris.sirhc@gmail.com"
+    },
+    {
+      "name": "Beau Gunderson",
+      "email": "beau@beaugunderson.com"
+    },
+    {
+      "name": "Dave Galbraith",
+      "email": "dave@jut.io"
+    },
+    {
+      "name": "s100",
+      "email": "shughes1@uk.ibm.com"
+    },
+    {
+      "name": "Sergey Simonchik",
+      "email": "sergey.simonchik@jetbrains.com"
+    },
+    {
+      "name": "Vanja Radovanović",
+      "email": "elvanja@gmail.com"
+    },
+    {
+      "name": "Jonathan Persson",
+      "email": "persson.jonathan@gmail.com"
+    },
+    {
+      "name": "Vedat Mahir YILMAZ",
+      "email": "mahir@vedatmahir.com"
+    },
+    {
+      "name": "Samuel Reed",
+      "email": "samuel.trace.reed@gmail.com"
+    },
+    {
+      "name": "Rafał Legiędź",
+      "email": "rafal.legiedz@gmail.com"
+    },
+    {
+      "name": "Jan Schär",
+      "email": "jscissr@gmail.com"
+    },
+    {
+      "name": "Xcat Liu",
+      "email": "xcatliu@gmail.com"
+    },
+    {
+      "name": "harryh",
+      "email": "Aourin@users.noreply.github.com"
+    },
+    {
+      "name": "Prayag Verma",
+      "email": "prayag.verma@gmail.com"
+    },
+    {
+      "name": "Neil Kistner",
+      "email": "neil.kistner@gmail.com"
+    },
+    {
+      "name": "Zoujie Wzj",
+      "email": "zoujie.wzj@alibaba-inc.com"
+    },
+    {
+      "name": "Ryan Hendrickson",
+      "email": "ryan.hendrickson@alum.mit.edu"
+    },
+    {
+      "name": "Arturo Coronel",
+      "email": "aoitsu3@gmail.com"
+    },
+    {
+      "name": "Hutson Betts",
+      "email": "hbetts@factset.com"
+    },
+    {
+      "name": "Lewis Cowper",
+      "email": "lewis.cowper@googlemail.com"
+    },
+    {
+      "name": "Adam Byrne",
+      "email": "misterbyrne@gmail.com"
+    },
+    {
+      "name": "Ifeanyi Oraelosi",
+      "email": "ifeanyioraelosi@gmail.com"
+    },
+    {
+      "name": "Robert Ludwig",
+      "email": "rob.ludwig@rideamigos.com"
+    },
+    {
+      "name": "Chris Warren",
+      "email": "chris@ixalon.net"
+    },
+    {
+      "name": "Scott Plumlee",
+      "email": "scott@plumlee.org"
+    },
+    {
+      "name": "Daniel Pedersen",
+      "email": "daniel@scandinav.se"
+    },
+    {
+      "name": "rhgb",
+      "email": "kaiserdaemon@gmail.com"
+    },
+    {
+      "name": "doug.wade",
+      "email": "doug.wade@redfin.com"
+    },
+    {
+      "name": "Zac",
+      "email": "zdoege@gm.slc.edu"
+    },
+    {
+      "name": "GriffinSchneider",
+      "email": "griffinschneider@gmail.com"
+    },
+    {
+      "name": "Andres Kalle",
+      "email": "mjomble@gmail.com"
+    },
+    {
+      "name": "thefourtheye",
+      "email": "thefourtheye@users.noreply.github.com"
+    },
+    {
+      "name": "Yael",
+      "email": "yaelz@users.noreply.github.com"
+    },
+    {
+      "name": "Yann Odeyer",
+      "email": "yann@odeyer.com"
+    },
+    {
+      "name": "James Monger",
+      "email": "jameskmonger@hotmail.co.uk"
+    },
+    {
+      "name": "Thomas Hallock",
+      "email": "thomas@1stdibs.com"
+    },
+    {
+      "name": "Paul Irish",
+      "email": "paul.irish@gmail.com"
+    },
+    {
+      "name": "Paul O'Leary McCann",
+      "email": "polm@dampfkraft.com"
+    },
+    {
+      "name": "Francis Gulotta",
+      "email": "wizard@roborooter.com"
+    },
+    {
+      "name": "Felix Rieseberg",
+      "email": "felix@felixrieseberg.com"
+    },
+    {
+      "name": "Glen Mailer",
+      "email": "glenjamin@gmail.com"
+    },
+    {
+      "name": "Federico Brigante",
+      "email": "bfred-it@users.noreply.github.com"
+    },
+    {
+      "name": "Steve Mao",
+      "email": "maochenyan@gmail.com"
+    },
+    {
+      "name": "Anna Henningsen",
+      "email": "anna@addaleax.net"
+    },
+    {
+      "name": "Rachel Evans",
+      "email": "git@rve.org.uk"
+    },
+    {
+      "name": "Sam Minnee",
+      "email": "sam@silverstripe.com"
+    },
+    {
+      "name": "Zirak",
+      "email": "zirakertan@gmail.com"
+    },
+    {
+      "name": "Daniel Lupu",
+      "email": "lupu.daniel.f@gmail.com"
+    },
+    {
+      "name": "Gianluca Casati",
+      "email": "fibo@users.noreply.github.com"
+    },
+    {
+      "name": "André Herculano",
+      "email": "andresilveirah@gmail.com"
+    },
+    {
+      "name": "Wyatt Preul",
+      "email": "wpreul@gmail.com"
+    },
+    {
+      "name": "Myles Borins",
+      "email": "mborins@us.ibm.com"
+    },
+    {
+      "name": "Elliot Lee",
+      "email": "github.public@intelliot.com"
+    },
+    {
+      "name": "Dmitry Kirilyuk",
+      "email": "gk.joker@gmail.com"
+    },
+    {
+      "name": "Aaron Tribou",
+      "email": "aaron.tribou@gmail.com"
+    },
+    {
+      "name": "Tapani Moilanen",
+      "email": "moilanen.tapani@gmail.com"
+    },
+    {
+      "name": "Han Seoul-Oh",
+      "email": "laughinghan@gmail.com"
+    },
+    {
+      "name": "Aleksey Shvayka",
+      "email": "shvaikalesh@gmail.com"
+    },
+    {
+      "name": "Emma Ramirez",
+      "email": "ramirez.emma.g@gmail.com"
+    },
+    {
+      "name": "Julian Duque",
+      "email": "julianduquej@gmail.com"
+    },
+    {
+      "name": "Simon MacDonald",
+      "email": "simon.macdonald@gmail.com"
+    },
+    {
+      "name": "Adam Stankiewicz",
+      "email": "sheerun@sher.pl"
+    },
+    {
+      "name": "Gregers Gram Rygg",
+      "email": "gregers.gram.rygg@finn.no"
+    },
+    {
+      "name": "Peter Dave Hello",
+      "email": "hsu@peterdavehello.org"
+    },
+    {
+      "name": "Jordan Klassen",
+      "email": "forivall@gmail.com"
+    },
+    {
+      "name": "Jason Palmer",
+      "email": "jason@jason-palmer.com"
+    },
+    {
+      "name": "Michael Hart",
+      "email": "michael.hart.au@gmail.com"
+    },
+    {
+      "name": "Sasha Koss",
+      "email": "koss@nocorp.me"
+    },
+    {
+      "name": "David Emmerson",
+      "email": "david.emmerson@gmail.com"
+    },
+    {
+      "name": "Christophe Hurpeau",
+      "email": "christophe@hurpeau.com"
+    },
+    {
+      "name": "Daniel Paz-Soldan",
+      "email": "daniel.pazsoldan@gmail.com"
+    },
+    {
+      "name": "Sakthipriyan Vairamani",
+      "email": "thechargingvolcano@gmail.com"
+    },
+    {
+      "name": "Zach Renner",
+      "email": "zarenner@microsoft.com"
+    },
+    {
+      "name": "Christopher Hiller",
+      "email": "boneskull@boneskull.com"
+    },
+    {
+      "name": "legodude17",
+      "email": "legodudejb@gmail.com"
+    },
+    {
+      "name": "Andrew Meyer",
+      "email": "andrewm.bpi@gmail.com"
+    },
+    {
+      "name": "Michael Jasper",
+      "email": "mdjasper@gmail.com"
+    },
+    {
+      "name": "Max",
+      "email": "contact@mstoiber.com"
+    },
+    {
+      "name": "Szymon Nowak",
+      "email": "szimek@gmail.com"
+    },
+    {
+      "name": "Jason Karns",
+      "email": "jason.karns@gmail.com"
+    },
+    {
+      "name": "Lucas Holmquist",
+      "email": "lholmqui@redhat.com"
+    },
+    {
+      "name": "Ionică Bizău",
+      "email": "bizauionica@gmail.com"
+    },
+    {
+      "name": "Alex Chesters",
+      "email": "AlexChesters@users.noreply.github.com"
+    },
+    {
+      "name": "Robert Gay",
+      "email": "robert.gay@redfin.com"
+    },
+    {
+      "name": "Steven",
+      "email": "stevokk@hotmail.com"
+    },
+    {
+      "name": "Tim Caswell",
+      "email": "tim@creationix.com"
+    },
+    {
+      "name": "Anna Henningsen",
+      "email": "github@addaleax.net"
+    },
+    {
+      "name": "Kim Røen",
+      "email": "kim@kimroen.com"
+    },
+    {
+      "name": "Douglas Wilson",
+      "email": "dougwilson@live.com"
+    },
+    {
+      "name": "Mike Engel",
+      "email": "mike@mike-engel.com"
+    },
+    {
+      "name": "baderbuddy",
+      "email": "baderbuddy@gmail.com"
+    },
+    {
+      "name": "Alex Jordan",
+      "email": "alex@strugee.net"
+    },
+    {
+      "name": "Ville Lahdenvuo",
+      "email": "tuhoojabotti@gmail.com"
+    },
+    {
+      "name": "Natalie Wolfe",
+      "email": "nwolfe@newrelic.com"
+    },
+    {
+      "name": "Andrew Schmadel",
+      "email": "aschmadel@learningobjects.com"
+    },
+    {
+      "name": "Jonah Moses",
+      "email": "jonahkmoses@gmail.com"
+    }
+  ],
+  "readme": "npm(1) -- a JavaScript package manager\n==============================\n[![Build Status](https://img.shields.io/travis/npm/npm/latest.svg)](https://travis-ci.org/npm/npm)\n## SYNOPSIS\n\nThis is just enough info to get you up and running.\n\nMuch more info available via `npm help` once it's installed.\n\n## IMPORTANT\n\n**You need node v0.10 or higher to run this program.**\n\nTo install an old **and unsupported** version of npm that works on node 0.3\nand prior, clone the git repo and dig through the old tags and branches.\n\n**npm is configured to use npm, Inc.'s public package registry at\n<https://registry.npmjs.org> by default.**\n\nYou can configure npm to use any compatible registry you\nlike, and even run your own registry. Check out the [doc on\nregistries](https://docs.npmjs.com/misc/registry).\n\nUse of someone else's registry may be governed by terms of use. The\nterms of use for the default public registry are available at\n<https://www.npmjs.com>.\n\n## Super Easy Install\n\nnpm is bundled with [node](https://nodejs.org/en/download/).\n\n### Windows Computers\n\n[Get the MSI](https://nodejs.org/en/download/).  npm is in it.\n\n### Apple Macintosh Computers\n\n[Get the pkg](https://nodejs.org/en/download/).  npm is in it.\n\n### Other Sorts of Unices\n\nRun `make install`.  npm will be installed with node.\n\nIf you want a more fancy pants install (a different version, customized\npaths, etc.) then read on.\n\n## Fancy Install (Unix)\n\nThere's a pretty robust install script at\n<https://www.npmjs.com/install.sh>.  You can download that and run it.\n\nHere's an example using curl:\n\n```sh\ncurl -L https://www.npmjs.com/install.sh | sh\n```\n\n### Slightly Fancier\n\nYou can set any npm configuration params with that script:\n\n```sh\nnpm_config_prefix=/some/path sh install.sh\n```\n\nOr, you can run it in uber-debuggery mode:\n\n```sh\nnpm_debug=1 sh install.sh\n```\n\n### Even Fancier\n\nGet the code with git.  Use `make` to build the docs and do other stuff.\nIf you plan on hacking on npm, `make link` is your friend.\n\nIf you've got the npm source code, you can also semi-permanently set\narbitrary config keys using the `./configure --key=val ...`, and then\nrun npm commands by doing `node cli.js <cmd> <args>`.  (This is helpful\nfor testing, or running stuff without actually installing npm itself.)\n\n## Windows Install or Upgrade\n\nMany improvements for Windows users have been made in npm 3 - you will have a better\nexperience if you run a recent version of npm. To upgrade, either use [Microsoft's\nupgrade tool](https://github.com/felixrieseberg/npm-windows-upgrade),\n[download a new version of Node](http://nodejs.org/download/),\nor follow the Windows upgrade instructions in the\n[npm Troubleshooting Guide](https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows).\n\nIf that's not fancy enough for you, then you can fetch the code with\ngit, and mess with it directly.\n\n## Installing on Cygwin\n\nNo.\n\n## Uninstalling\n\nSo sad to see you go.\n\n```sh\nsudo npm uninstall npm -g\n```\nOr, if that fails,\n\n```sh\nsudo make uninstall\n```\n\n## More Severe Uninstalling\n\nUsually, the above instructions are sufficient.  That will remove\nnpm, but leave behind anything you've installed.\n\nIf you would like to remove all the packages that you have installed,\nthen you can use the `npm ls` command to find them, and then `npm rm` to\nremove them.\n\nTo remove cruft left behind by npm 0.x, you can use the included\n`clean-old.sh` script file.  You can run it conveniently like this:\n\n```sh\nnpm explore npm -g -- sh scripts/clean-old.sh\n```\n\nnpm uses two configuration files, one for per-user configs, and another\nfor global (every-user) configs.  You can view them by doing:\n\n```sh\nnpm config get userconfig   # defaults to ~/.npmrc\nnpm config get globalconfig # defaults to /usr/local/etc/npmrc\n```\n\nUninstalling npm does not remove configuration files by default.  You\nmust remove them yourself manually if you want them gone.  Note that\nthis means that future npm installs will not remember the settings that\nyou have chosen.\n\n## More Docs\n\nCheck out the [docs](https://docs.npmjs.com/),\n\nYou can use the `npm help` command to read any of them.\n\nIf you're a developer, and you want to use npm to publish your program,\nyou should [read this](https://docs.npmjs.com/misc/developers)\n\n## BUGS\n\nWhen you find issues, please report them:\n\n* web:\n  <https://github.com/npm/npm/issues>\n\nBe sure to include *all* of the output from the npm command that didn't work\nas expected.  The `npm-debug.log` file is also helpful to provide.\n\nYou can also look for isaacs in #node.js on irc://irc.freenode.net.  She\nwill no doubt tell you to put the output in a gist or email.\n\n## SEE ALSO\n\n* npm(1)\n* npm-help(1)\n* npm-index(7)\n",
+  "readmeFilename": "README.md",
+  "_id": "npm@4.1.2",
+  "_shasum": "8596feaf86c32034029aa5f150ed0ea3fc0f15ae",
+  "_resolved": "https://github.com/npm/npm/archive/v4.1.2.tar.gz",
+  "_from": "https://github.com/npm/npm/archive/v4.1.2.tar.gz"
+}

--- a/test/fixtures/tarball-pass/package.json
+++ b/test/fixtures/tarball-pass/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tarball-pass",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "npm": "https://github.com/npm/npm/archive/v4.1.2.tar.gz"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/test.test.js
+++ b/test/test.test.js
@@ -67,3 +67,27 @@ test('works with modules split acorss different node_module folders', function(a
     assert.end();
   });
 });
+
+test('validates and pass tarballs', function(assert) {
+  checkFileDependencies(path.join(__dirname, 'fixtures', 'tarball-pass', 'index.js'), function(err) {
+    assert.ifError(err, 'this module should be good');
+    assert.end();
+  });
+});
+
+test('validates and fails tarballs based on bad versions', function(assert) {
+  checkFileDependencies(path.join(__dirname, 'fixtures', 'tarball-fail-version', 'index.js'), function(err) {
+    if (err === undefined) return assert.end(new Error('expected an error'));
+    assert.equal(err.message, 'Expected version 4.1.17 of npm but found 3.10.10', 'right error message');
+    assert.end();
+  });
+});
+
+test('validates and fails tarballs based on bad versions', function(assert) {
+  checkFileDependencies(path.join(__dirname, 'fixtures', 'tarball-fail-package', 'index.js'), function(err) {
+    if (err === undefined) return assert.end(new Error('expected an error'));
+    assert.equal(err.message, 'Expected npm but found jsonify', 'right error message');
+    assert.end();
+  });
+});
+

--- a/test/test.test.js
+++ b/test/test.test.js
@@ -78,7 +78,7 @@ test('validates and pass tarballs', function(assert) {
 test('validates and fails tarballs based on bad versions', function(assert) {
   checkFileDependencies(path.join(__dirname, 'fixtures', 'tarball-fail-version', 'index.js'), function(err) {
     if (err === undefined) return assert.end(new Error('expected an error'));
-    assert.equal(err.message, 'Expected version 4.1.17 of npm but found 3.10.10', 'right error message');
+    assert.equal(err.message, 'Expected version 4.1.2 of npm but found 3.10.10', 'right error message');
     assert.end();
   });
 });
@@ -86,7 +86,7 @@ test('validates and fails tarballs based on bad versions', function(assert) {
 test('validates and fails tarballs based on bad versions', function(assert) {
   checkFileDependencies(path.join(__dirname, 'fixtures', 'tarball-fail-package', 'index.js'), function(err) {
     if (err === undefined) return assert.end(new Error('expected an error'));
-    assert.equal(err.message, 'Expected npm but found jsonify', 'right error message');
+    assert.equal(err.message, 'Found name:jsonify in package.json from at https://github.com/substack/jsonify/tarball/master. Expected npm', 'right error message');
     assert.end();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,20 +2,9 @@
 # yarn lockfile v1
 
 
-JSONStream@^1.0.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.0.tgz#680ab9ac6572a8a1a207e0b38721db1c77b215e5"
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
-
 acorn@^1.0.3:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-1.2.2.tgz#c8ce27de0acc76d896d2b1fad3df588d9e82f014"
-
-acorn@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
 astw@2.0.0:
   version "2.0.0"
@@ -27,6 +16,12 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+block-stream@*:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  dependencies:
+    inherits "~2.0.0"
+
 brace-expansion@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
@@ -34,35 +29,19 @@ brace-expansion@^1.0.0:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
 
-browser-resolve@^1.7.0:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
-  dependencies:
-    resolve "1.1.7"
-
-buffer-shims@^1.0.0:
+capture-stack-trace@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
-
-cached-path-relative@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.0.0.tgz#d1094c577fbd9a8b8bd43c96af6188aa205d05f4"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@~1.5.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
+create-error-class@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
   dependencies:
-    inherits "~2.0.1"
-    readable-stream "~2.0.0"
-    typedarray "~0.0.5"
-
-core-util-is@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+    capture-stack-trace "^1.0.0"
 
 deep-equal@~1.0.1:
   version "1.0.1"
@@ -75,22 +54,13 @@ define-properties@^1.1.2:
     foreach "^2.0.5"
     object-keys "^1.0.8"
 
-defined@^1.0.0, defined@~1.0.0:
+defined@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
-detective@^4.0.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/detective/-/detective-4.3.2.tgz#77697e2e7947ac3fe7c8e26a6d6f115235afa91c"
-  dependencies:
-    acorn "^3.1.0"
-    defined "^1.0.0"
-
-duplexer2@^0.1.2, duplexer2@~0.1.0:
+duplexer3@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
-  dependencies:
-    readable-stream "^2.0.2"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
 es-abstract@^1.5.0:
   version "1.7.0"
@@ -123,11 +93,24 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+fstream@^1.0.2:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.10.tgz#604e8a92fe26ffd9f6fae30399d4984e1ab22822"
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 function-bind@^1.0.2, function-bind@^1.1.0, function-bind@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
-glob@~7.1.1:
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+glob@^7.0.5, glob@~7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -137,6 +120,26 @@ glob@~7.1.1:
     minimatch "^3.0.2"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
+    url-parse-lax "^1.0.0"
+
+graceful-fs@^4.1.2:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
 has@~1.0.1:
   version "1.0.1"
@@ -151,7 +154,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -167,21 +170,29 @@ is-function@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+
 is-regex@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.3.tgz#0d55182bddf9f2fde278220aec3a75642c908637"
+
+is-retry-allowed@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
+
+is-stream@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
-isarray@~1.0.0:
+lowercase-keys@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-jsonparse@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.0.tgz#85fc245b1d9259acc6941960b905adf64e7de0e8"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
 minimatch@^3.0.2:
   version "3.0.3"
@@ -189,29 +200,19 @@ minimatch@^3.0.2:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimist@^1.1.0, minimist@~1.2.0:
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-module-deps@4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-4.0.8.tgz#55fd70623399706c3288bef7a609ff1e8c0ed2bb"
+"mkdirp@>=0.5 0":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
-    JSONStream "^1.0.3"
-    browser-resolve "^1.7.0"
-    cached-path-relative "^1.0.0"
-    concat-stream "~1.5.0"
-    defined "^1.0.0"
-    detective "^4.0.0"
-    duplexer2 "^0.1.2"
-    inherits "^2.0.1"
-    parents "^1.0.0"
-    readable-stream "^2.0.2"
-    resolve "^1.1.3"
-    stream-combiner2 "^1.1.1"
-    subarg "^1.0.0"
-    through2 "^2.0.0"
-    xtend "^4.0.0"
+    minimist "0.0.8"
 
 object-inspect@~1.2.1:
   version "1.2.1"
@@ -227,7 +228,7 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-parents@1.0.1, parents@^1.0.0:
+parents@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parents/-/parents-1.0.1.tgz#fedd4d2bf193a77745fe71e371d73c3307d9c751"
   dependencies:
@@ -241,40 +242,17 @@ path-platform@~0.11.15:
   version "0.11.15"
   resolved "https://registry.yarnpkg.com/path-platform/-/path-platform-0.11.15.tgz#e864217f74c36850f0852b78dc7bf7d4a5721bf2"
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+prepend-http@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
-readable-stream@^2.0.2, readable-stream@^2.1.5:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
-  dependencies:
-    buffer-shims "^1.0.0"
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-readable-stream@~2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-resolve@1.1.7, resolve@~1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-
-resolve@1.2.0, resolve@^1.1.3:
+resolve@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.2.0.tgz#9589c3f2f6149d1417a40becc1663db6ec6bc26c"
+
+resolve@~1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resumer@~0.0.0:
   version "0.0.0"
@@ -282,16 +260,19 @@ resumer@~0.0.0:
   dependencies:
     through "~2.3.4"
 
+rimraf@2:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
+  dependencies:
+    glob "^7.0.5"
+
+safe-buffer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
 semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-
-stream-combiner2@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stream-combiner2/-/stream-combiner2-1.1.1.tgz#fb4d8a1420ea362764e21ad4780397bebcb41cbe"
-  dependencies:
-    duplexer2 "~0.1.0"
-    readable-stream "^2.0.2"
 
 string.prototype.trim@~1.1.2:
   version "1.1.2"
@@ -300,16 +281,6 @@ string.prototype.trim@~1.1.2:
     define-properties "^1.1.2"
     es-abstract "^1.5.0"
     function-bind "^1.0.2"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-
-subarg@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
-  dependencies:
-    minimist "^1.1.0"
 
 tape@4.6.3:
   version "4.6.3"
@@ -329,29 +300,32 @@ tape@4.6.3:
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
 
-through2@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+tar@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   dependencies:
-    readable-stream "^2.1.5"
-    xtend "~4.0.1"
+    block-stream "*"
+    fstream "^1.0.2"
+    inherits "2"
 
-"through@>=2.2.7 <3", through@~2.3.4, through@~2.3.8:
+through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-typedarray@~0.0.5:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+timed-out@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
-util-deprecate@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+
+url-parse-lax@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
+  dependencies:
+    prepend-http "^1.0.1"
 
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-
-xtend@^4.0.0, xtend@~4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"


### PR DESCRIPTION
This unzips and untars url dependencies. It assumes that all urls are gziped tarballs, [which does not cover every npm url condition](https://github.com/npm/npm/blob/d081cc6c8d73f2aa698aab36605377c95e916224/lib/utils/tar.js#L366-L429), but I couldn't find a module that did and this at least enabled URL dependencies.

@emilymcafee 👀 