### PR TITLE
List file's dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![](https://travis-ci.org/mapbox/check-file-dependencies.svg?branch=master)](https://travis-ci.org/mapbox/check-file-dependencies)
 
-Takes a file path and checks to see if the modules it requires match the package.json
+Takes a file path and checks to see if the modules installed match what is in the package.json
 
 ## Usage
 
@@ -19,4 +19,10 @@ Or as a CLI
 
 ```
 check-file-dependencies ./path/to/file.js
+```
+
+### To list dependencies
+
+```
+check-file-dependencies --list-deps ./path/to/file.js
 ```

--- a/bin/cli
+++ b/bin/cli
@@ -2,8 +2,15 @@
 
 var path = require('path');
 var cfd = require('..');
+var listCmd = require('./list');
 
 var file = process.argv[2];
+
+var list = file === '--list-deps' ? true : false;
+
+if (list) {
+  file = process.argv[3];
+}
 
 if (file === undefined) {
   console.log('Must supply a file');
@@ -11,6 +18,10 @@ if (file === undefined) {
 
 if (file[0] !== '/') {
   file = path.join(process.cwd(), file);
+}
+
+if (list) {
+  return listCmd(file);
 }
 
 cfd(file, function(err) {

--- a/bin/list.js
+++ b/bin/list.js
@@ -1,0 +1,28 @@
+var parents = require('parents');
+
+var findPackageJSON = require('../lib/find-package-json.js');
+var findUsedModules = require('../lib/find-used-modules');
+
+module.exports = function(filePath, callback) {
+
+  var data = {
+    folders: parents(filePath),
+    idx: 0,
+    filePath: filePath
+  }
+
+  findPackageJSON(data)
+    .then(findUsedModules)
+    .then(function(data) {
+      data.modules.forEach(m => {
+        var dep = data.packageJSON.dependencies[m];
+        var dev = data.packageJSON.devDependencies[m];
+        console.log(m+'@'+(dep || dev));
+      });
+    })
+    .catch(err => {
+      throw err;
+    });
+
+};
+


### PR DESCRIPTION
Currently this module just returns an error if the modules required by a file are not in the package.json or the versions installed in `node_modules` doesn't match what is in the package.json.

This PR starts to expand the functionality to find what modules are required by a file. An error will still be thrown if the module required is not in the package.json.

- [ ] add tests
- [ ] expose this as a function on the node modules rather than just as a cli option

cc @rclark for thoughts