### PR TITLE
Make this a node module and not just a cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![](https://travis-ci.org/mapbox/check-file-dependencies.svg?branch=master)](https://travis-ci.org/mapbox/check-file-dependencies)
 
-Takes a file path and checks to see if the modules it requires match the package.json
+Takes a file path and checks to see if the modules installed match what is in the package.json
 
 ## Usage
 
@@ -19,4 +19,10 @@ Or as a CLI
 
 ```
 check-file-dependencies ./path/to/file.js
+```
+
+### To list dependencies
+
+```
+check-file-dependencies --list-deps ./path/to/file.js
 ```

--- a/bin/cli
+++ b/bin/cli
@@ -2,8 +2,15 @@
 
 var path = require('path');
 var cfd = require('..');
+var listCmd = require('./list');
 
 var file = process.argv[2];
+
+var list = file === '--list-deps' ? true : false;
+
+if (list) {
+  file = process.argv[3];
+}
 
 if (file === undefined) {
   console.log('Must supply a file');
@@ -11,6 +18,10 @@ if (file === undefined) {
 
 if (file[0] !== '/') {
   file = path.join(process.cwd(), file);
+}
+
+if (list) {
+  return listCmd(file);
 }
 
 cfd(file, function(err) {

--- a/bin/list.js
+++ b/bin/list.js
@@ -1,0 +1,28 @@
+var parents = require('parents');
+
+var findPackageJSON = require('../lib/find-package-json.js');
+var findUsedModules = require('../lib/find-used-modules');
+
+module.exports = function(filePath, callback) {
+
+  var data = {
+    folders: parents(filePath),
+    idx: 0,
+    filePath: filePath
+  }
+
+  findPackageJSON(data)
+    .then(findUsedModules)
+    .then(function(data) {
+      data.modules.forEach(m => {
+        var dep = data.packageJSON.dependencies[m];
+        var dev = data.packageJSON.devDependencies[m];
+        console.log(m+'@'+(dep || dev));
+      });
+    })
+    .catch(err => {
+      throw err;
+    });
+
+};
+

--- a/index.js
+++ b/index.js
@@ -4,21 +4,79 @@ var findPackageJSON = require('./lib/find-package-json.js');
 var findUsedModules = require('./lib/find-used-modules');
 var vetModules = require('./lib/vet');
 
-module.exports = function(filePath, callback) {
+module.exports = function(filePath) {
+  const folders = parents(filePath);
+  var api = {};
 
-  var data = {
-    folders: parents(filePath),
-    idx: 0,
-    filePath: filePath
+  var packagePromise = null;
+  var nodeMoudlesPromise = null;
+
+  api.modules = function() {
+    findUsedModules({
+      folders, idx: 0, filePath
+    }).then(data => callback(null, data.modules)).catch(cb);
   }
 
-  findPackageJSON(data)
-    .then(findUsedModules)
-    .then(vetModules)
-    .then(data => callback())
-    .catch(err => callback(err));
+  api.nodeModulesVersion = function(module) {
+    if (nodeMoudlesPromise === null) {
+      nodeMoudlesPromise = findLocalVersions(parents);
+    }
 
-};
+    nodeMoudlesPromise.then(data => {
+      var version = data[module];
 
+      return {
+        module, version
+      }
+    })
 
+  };
+
+  api.packagedVersion = function(module) {
+    if (packagePromise === null) {
+      packagePromise = findPackageJSON({
+        parents, idx: 0, filePath
+      });
+    }
+
+    packagePromise.then(data => {
+      var dev = data.devDependencies[module];
+      var dep = data.dependencies[module];
+      var peer = data.peerDependencies[module];
+
+      var version = [dev, dep, peer].filter(v => v !== undefined).reduce((a, b) => {
+        if (a !== b) throw new Error('Ambigous version in package.json for '+module);
+      });
+
+      return {
+        module, version
+      };
+    });
+  };
+
+  api.outOfDateModules = function() {
+    api.modules().then(modules => {
+      return Promise.all([api.packagedVersion, api.nodeModulesVersion].map(fn => {
+        return Promise.all(modules.map(module => {
+          return fn(module);
+        }));
+      }));
+    }).then(results => {
+      var packaged = results[0].reduce((m, v) => {
+        m[v.module] = v.version;
+        return m;
+      }, {});
+
+      return results[1].filter(v => packaged[v.module] !== v.version).map(v => {
+        var out = {};
+        out.module = v.module;
+        out.packageJson = packaged[v.module];
+        out.nodeModules = v.version || 'not installed';
+        return out;
+      });
+    });
+  }
+
+  return api;
+}
 


### PR DESCRIPTION
Right now this module is really a cli that has been hacked to a bit more. This PR moves away from that design so that it can be used to ask questions about a files dependencies rather than simply throwing errors when unexpected versions arise.

- [ ] Overhaul tests
- [ ] Update the cli
- [ ] Refresh docs
- [ ] Make sure we handle things like `require('csv-parse/lib/sync')` properly