### PR TITLE
Allow hashbang

### DIFF
--- a/lib/find-used-modules.js
+++ b/lib/find-used-modules.js
@@ -28,6 +28,7 @@ function parseFile(file, dirname) {
         if (err) return reject(err);
         var ast = parse(str.toString(), {
           ecmaVersion: 9,
+          allowHashBang: true,
           allowReturnOutsideFunction: true
         });
         var children = [];

--- a/test/fixtures/hashbang/cli.js
+++ b/test/fixtures/hashbang/cli.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+'use strict';
+const foo = 'bar';
+const main = module.exports = () => console.log(foo);
+
+if (require.main === module) {
+  main();
+}

--- a/test/test.test.js
+++ b/test/test.test.js
@@ -68,6 +68,13 @@ test('works with modules split acorss different node_module folders', function(a
   });
 });
 
+test('works with a module that includes a hashbang for command-line usage', function (assert) {
+  checkFileDependencies(path.join(__dirname, 'fixtures', 'hashbang', 'cli.js'), function (err) {
+    assert.ifError(err, 'this module should be good');
+    assert.end();
+  });
+});
+
 test('validates and pass tarballs', function(assert) {
   checkFileDependencies(path.join(__dirname, 'fixtures', 'tarball-pass', 'index.js'), function(err) {
     assert.ifError(err, 'this module should be good');
@@ -97,6 +104,5 @@ test('fails if the file requires evaluation to determine require path', function
     assert.equal(err.message, 'Unable to resolve require(\'hi\' + \'bye\') in test/fixtures/eval-require/index.js', 'right error message');
     assert.end();
   });
-        
 });
 


### PR DESCRIPTION
This configures acorn to allow parsing modules having a valid hashbang.

It's not uncommon to use the same file as both a module and an executable cli script, such as the added text fixture: https://github.com/mapbox/check-file-dependencies/compare/allow-hashbang?expand=1#diff-109d1d9482dcaa97aaace8500ae65888