### PR TITLE
tar@2.2.2 and fstream@1.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Check File Dependencies Changelog
 
+## 3.2.1
+
+- tar@2.2.2 and fstream@1.0.12 according to security alerts
+
 ## 3.2.0
 
 - Add support for `!#/usr/bin/env node` or `hasbang` scripts.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "parents": "1.0.1",
     "resolve": "1.2.0",
     "semver": "^5.3.0",
-    "tar": "^2.2.1"
+    "tar": "2.2.2"
   },
   "devDependencies": {
     "tape": "4.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,9 +122,10 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fstream@^1.0.2:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.10.tgz#604e8a92fe26ffd9f6fae30399d4984e1ab22822"
+fstream@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
   dependencies:
     graceful-fs "^4.1.2"
     inherits "~2.0.0"
@@ -357,12 +358,13 @@ tape@4.6.3:
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
 
-tar@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
+tar@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
+  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
   dependencies:
     block-stream "*"
-    fstream "^1.0.2"
+    fstream "^1.0.12"
     inherits "2"
 
 through@~2.3.4, through@~2.3.8:


### PR DESCRIPTION
Fixes the security alerts

![2019-06-04 at 12 52](https://user-images.githubusercontent.com/25713/58873888-9fda2b80-86c7-11e9-8408-45f0e357ee3a.png)

Todo:

- [ ] Merge
- [ ] Bump version and publish