### PR TITLE
update acorn, install acorn-walk

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Check File Dependencies Changelog
 
+## UNRELEASED
+
+- Drop support for node 12 and 14
+- Add support for node 18 and 20
+- Update acorn to v8.x
+  - This introduces a dependency to acorn-walk
+
 ## 4.0.0
+
 - Drop support for node 6 and 8
 - Add support for node 12 and 14
 - Security Vulnerability Fix

--- a/lib/find-used-modules.js
+++ b/lib/find-used-modules.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var fs = require('fs');
 var parse = require('acorn').parse;
-var walk = require('acorn/dist/walk');
+var walk = require('acorn-walk');
 var parents = require('parents');
 var resolveModule = require('resolve');
 var decode = require('escodegen').generate;
@@ -27,7 +27,7 @@ function parseFile(file, dirname) {
         if (err && addJs) return parseFile(path.join(file, 'index.js')).then(resolve).catch(reject);
         if (err) return reject(err);
         var ast = parse(str.toString(), {
-          ecmaVersion: 9,
+          ecmaVersion: 2023,
           allowHashBang: true,
           allowReturnOutsideFunction: true
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,11 @@
   "packages": {
     "": {
       "name": "@mapbox/check-file-dependencies",
-      "version": "3.2.1",
+      "version": "4.0.0",
       "license": "ISC",
       "dependencies": {
-        "acorn": "^5.5.3",
+        "acorn": "^8.10.0",
+        "acorn-walk": "^8.2.0",
         "escodegen": "^1.8.1",
         "got": "^6.7.1",
         "parents": "1.0.1",
@@ -25,12 +26,20 @@
       }
     },
     "node_modules/acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "bin": {
         "acorn": "bin/acorn"
       },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -759,9 +768,14 @@
   },
   "dependencies": {
     "acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "amdefine": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
       },
       "devDependencies": {
         "tape": "4.6.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Takes a file path and checks to see if the modules it requires match the package.json",
   "version": "4.0.0",
   "main": "index.js",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "acorn": "^8.10.0",
     "acorn-walk": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "4.0.0",
   "main": "index.js",
   "dependencies": {
-    "acorn": "^5.5.3",
+    "acorn": "^8.10.0",
+    "acorn-walk": "^8.2.0",
     "escodegen": "^1.8.1",
     "got": "^6.7.1",
     "parents": "1.0.1",


### PR DESCRIPTION
This updates `acorn` to the latest major version, which adds support for more modern EcmaScript versions. This is particularly relevant as more and more modern javascript syntax sneaks into infrastructure code. Specifically, the new AWS SDK v3 promotes `for await ... of` in their paginators, which are likely to be used much more in the future. 

This also adds `acorn-walk` which is released as a separate module https://github.com/acornjs/acorn/tree/master/acorn-walk