### PR TITLE
Add file name to syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Check File Dependencies Changelog
 
-## UNRELEASED
+## 5.0.0
 
 - Drop support for node 12 and 14
 - Add support for node 18 and 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Drop support for node 12 and 14
 - Add support for node 18 and 20
+- Add filename to parsing error raised by acorn when attempting to parse invalid Javascript
 - Update acorn to v8.x
   - This introduces a dependency to acorn-walk
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Check File Dependencies
 
-[![](https://travis-ci.org/mapbox/check-file-dependencies.svg?branch=master)](https://travis-ci.org/mapbox/check-file-dependencies)
-
 Takes a file path and checks to see if the modules it requires match the package.json
 
 ## Usage

--- a/lib/find-used-modules.js
+++ b/lib/find-used-modules.js
@@ -26,11 +26,20 @@ function parseFile(file, dirname) {
     fs.readFile(file + (addJs ? '.js' : ''), function(err, str) {
         if (err && addJs) return parseFile(path.join(file, 'index.js')).then(resolve).catch(reject);
         if (err) return reject(err);
-        var ast = parse(str.toString(), {
-          ecmaVersion: 2023,
-          allowHashBang: true,
-          allowReturnOutsideFunction: true
-        });
+        let ast;
+        try {
+          ast = parse(str.toString(), {
+            ecmaVersion: 2023,
+            allowHashBang: true,
+            allowReturnOutsideFunction: true
+          });
+        } catch (error) {
+          if (error instanceof SyntaxError) {
+            error.message = error.message + ' in ' + displayPath;
+          }
+          return reject(error)
+        }
+        
         var children = [];
         var modules = [];
         walk.full(ast, function(node) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/check-file-dependencies",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/check-file-dependencies",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "ISC",
       "dependencies": {
         "acorn": "^8.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/check-file-dependencies",
   "description": "Takes a file path and checks to see if the modules it requires match the package.json",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "main": "index.js",
   "engines": {
     "node": ">=18"

--- a/test/fixtures/bad-code/expected-file-name.js
+++ b/test/fixtures/bad-code/expected-file-name.js
@@ -1,0 +1,2 @@
+// invalid javascript
+vat p = require('hi' + 'bye');

--- a/test/test.test.js
+++ b/test/test.test.js
@@ -9,6 +9,14 @@ test('works on itself', function(assert) {
   });
 });
 
+test('throws a syntax error if the file is not valid javascript', function(assert) {
+  checkFileDependencies(path.join(__dirname, 'fixtures', 'bad-code', 'expected-file-name.js'), function(err) {
+    assert.is(err instanceof SyntaxError, true, 'is a syntax error');
+    assert.ok(err.message.includes('expected-file-name.js'), 'contains the file name in the syntax error');
+    assert.end();
+  });
+})
+
 test('works with a bunch of modules in one folder', function(assert) {
   checkFileDependencies(path.join(__dirname, 'fixtures', 'good-npm', 'index.js'), function(err) {
     assert.ifError(err, 'this module should be good');
@@ -19,6 +27,7 @@ test('works with a bunch of modules in one folder', function(assert) {
 test('works with ambigous ranges where a very low version is installed', function(assert) {
   checkFileDependencies(path.join(__dirname, 'fixtures', 'ambiguous-low', 'index.js'), function(err) {
     assert.ifError(err, 'this module should be good');
+    
     assert.end();
   });
 });


### PR DESCRIPTION
Acorn throws a SyntaxError if it fails to parse a javascript file. That is all well and good, but the library currently just bubbles that up to the consumer. This is problematic for the reasons that it does not include the filename that contains the dodgy code. Granted, it's incapable of doing so as it's given the contents of the file, not the file itself.

 For now, let's staple that into the message on SyntaxError as it bubbles up the stack