### PR TITLE
change hash from md5 to sha256 to make prisma happy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Check File Dependencies Changelog
 
+## 6.0.1
+
+- Change an internal hash used to make comparisons from md5 to sha256 (because of a Prisma complaint)
+
 ## 6.0.0
 - Dropping support for Node 18 and 20
 - Add support for node 22+

--- a/lib/vet/tarball.js
+++ b/lib/vet/tarball.js
@@ -54,11 +54,11 @@ function vetPackageJSON(dir, fileStream) {
 
 function vetFile(dir, fileStream) {
   return getContentFromStream(fileStream).then(function(inTarball) {
-    var md5InTarball = crypto.createHash('md5').update(inTarball).digest("hex");
+    var md5InTarball = crypto.createHash('sha256').update(inTarball).digest("hex");
     var filePath = path.join(dir, fileStream.path.split('/').slice(1).join('/'));
     return getLocalFile(filePath).then(function(localFile) {
       localFile = transform(fileStream.path.split('/')[1], localFile);
-      var md5Local = crypto.createHash('md5').update(localFile).digest("hex");
+      var md5Local = crypto.createHash('sha256').update(localFile).digest("hex");
       if (md5Local !== md5InTarball) throw new Error('Files dont match');       
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/check-file-dependencies",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/check-file-dependencies",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "ISC",
       "dependencies": {
         "acorn": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/check-file-dependencies",
   "description": "Takes a file path and checks to see if the modules it requires match the package.json",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "main": "index.js",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
Prisma is complaining about this insecure hash. Changing it doesn't affect the library so we might as well.