### PR TITLE
Enable automerge for non-major Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,22 @@
   ],
   "packageRules": [
     {
+      "matchUpdateTypes": ["patch"],
+      "addLabels": ["patch"],
+      "automerge": true,
+      "autoApprove": true
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "addLabels": ["minor"],
+      "automerge": true,
+      "autoApprove": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major"]
+    },
+    {
       "description": "Group AWS SDK and @mapbox/cloudfriend together.",
       "matchManagers": ["npm"],
       "matchDepTypes": ["dependencies"],


### PR DESCRIPTION
## Summary
- Add patch/minor packageRules with `automerge: true` + `autoApprove: true`
- Add label-only rule for major updates
- Matches the api-identity reference config

## Why
The repo has `platformAutomerge: true` but no `automerge: true` rule in `packageRules`, so Renovate never enables the GitHub auto-merge button on any PR. The shared `:grouping` config covers groups, not update-type-based automerge, so non-major PRs sit BLOCKED on required review indefinitely.

## Test plan
- [ ] Merge and observe that the next non-major Renovate PR opens with auto-merge enabled and merges on its own after CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)