### PR TITLE
CLOUDPLAT-3162: add npm-release environment gate (check-file-dependencies)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -9,5 +9,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    environment: npm-release
     with:
       create-github-release: true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/check-file-dependencies",
   "description": "Takes a file path and checks to see if the modules it requires match the package.json",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "main": "index.js",
   "engines": {
     "node": ">=24.17.0"


### PR DESCRIPTION
Adding `environment: npm-release` to the npm release workflow.