### PR TITLE
CLOUDPLAT-3162: fix npm-release environment input (check-file-dependencies)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -9,6 +9,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    environment: npm-release
     with:
       create-github-release: true
+      environment: npm-release


### PR DESCRIPTION
Moving `environment: npm-release` from the job level into the `with:` block so it's passed as an input to the reusable workflow.